### PR TITLE
"AttributeError: 'dict' object has no attribute 'startswith'" 

### DIFF
--- a/src/oidcendpoint/client_authn.py
+++ b/src/oidcendpoint/client_authn.py
@@ -202,6 +202,12 @@ def verify_client(endpoint_context, request, authorization_info=None):
         possibly access token.
     """
 
+    # fixes request = {} instead of str
+    # "AttributeError: 'dict' object has no attribute 'startswith'" in oidcendpoint/endpoint.py(158)client_authentication()
+    if isinstance(authorization_info, dict):
+        strings_parade = ('{} {}'.format(k,v) for k,v in authorization_info.items())
+        authorization_info = ' '.join(strings_parade)
+
     if authorization_info is None:
         if 'client_id' in request and 'client_secret' in request:
             auth_info = ClientSecretPost(endpoint_context).verify(request)

--- a/src/oidcendpoint/endpoint.py
+++ b/src/oidcendpoint/endpoint.py
@@ -23,12 +23,12 @@ method call structure for Endpoints:
 parse_request
     - client_authentication (*)
     - post_parse_request (*)
-    
+
 process_request
 
-do_response    
+do_response
     - response_info
-        - construct 
+        - construct
             - pre_construct (*)
             - _parse_args
             - post_construct (*)


### PR DESCRIPTION
in oidcendpoint/endpoint.py(158)client_authentication()
because using gunicorn request appears as a dict {}

Now patched, maybe need a semantic revision.
modified:   src/oidcendpoint/client_authn.py