### PR TITLE
ImportError: No module named 'oic'

### DIFF
--- a/src/oidcendpoint/oidc/read_registration.py
+++ b/src/oidcendpoint/oidc/read_registration.py
@@ -1,4 +1,4 @@
-from oic.oauth2 import ErrorResponse
+from oidcmsg.oauth2 import AuthorizationErrorResponse
 from oidcmsg.message import Message
 from oidcmsg.oidc import RegistrationResponse
 
@@ -9,7 +9,7 @@ from oidcendpoint.oidc.registration import comb_uri
 class RegistrationRead(Endpoint):
     request_cls = Message
     response_cls = RegistrationResponse
-    error_response = ErrorResponse
+    error_response = AuthorizationErrorResponse
     request_format = "urlencoded"
     request_placement = "url"
     response_format = "json"


### PR DESCRIPTION
Fixed

oidcendpoint/oidc/read_registration.py", line 1, in <module>
   from oic.oauth2 import ErrorResponse
ImportError: No module named 'oic'

Probably you get it from pyoidc.
When I rebuilded the env I found this, hope to have made a good work