### PR TITLE
Custom sessiondb

### DIFF
--- a/src/oidcendpoint/session.py
+++ b/src/oidcendpoint/session.py
@@ -565,7 +565,8 @@ class SessionDB(object):
                 raise ValueError("No Authn event info")
 
 
-def create_session_db(ec, token_handler_args, db=None, sso_db=SSODb(), sub_func=None):
+def create_session_db(ec, token_handler_args, db=None,
+                      sso_db=SSODb(), sub_func=None):
     _token_handler = token_handler.factory(ec, **token_handler_args)
 
     if not db:


### PR DESCRIPTION
With this Commit I can set a session_db in a context_endpoint whenever it's needed.
Used here:
https://github.com/peppelinux/django-oidc-op/blob/master/oidc_op/application.py#L49

With this feature I can switch the session db runtime. For example I would use an user's  request.session as backend, on each request.

This is a more flexible approach and let me configure this aspect in a more granular way during the application (oidc-op) initialization and runtime.

This is the base I need, if it is there some other approach let's discuss them.
I need this commits to move to a pure Django Session and SSO Db management.

https://docs.djangoproject.com/en/2.2/topics/http/sessions/