### PR TITLE
nightly contributions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@ __pycache__/
 *.py[cod]
 *$py.class
 
+private/
+
 # C extensions
 *.so
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,24 @@
+dist: buster
+sudo: false
+
+language: python
+python:
+  - 3.6
+  - 3.7
+  - pypy3
+
+addons:
+  apt:
+    packages:
+      - 
+
+install:
+  - pip install pytest
+  - pip install codecov
+
+script:
+  - codecov --version
+  - tox
+
+after_success:
+  - codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,6 @@ install:
 
 script:
   - codecov --version
-  - tox
 
 after_success:
   - codecov

--- a/README.md
+++ b/README.md
@@ -1,2 +1,8 @@
 # oidcendpoint
 Implementation of OIDC OP endpoints. 
+
+## Run tests
+````
+pip install -r requirements-dev.txt
+pytest -x --pdb tests/
+````

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,3 @@
+pytest
+pytest-localserver
+requests_mock

--- a/src/oidcendpoint/id_token.py
+++ b/src/oidcendpoint/id_token.py
@@ -249,11 +249,8 @@ class IDToken(object):
             _client_id = req["client_id"]
 
         _cinfo = _context.cdb[_client_id]
-        try:
-            default_idtoken_claims = self.kwargs["default_claims"]
-        except KeyError:
-            default_idtoken_claims = None
 
+        default_idtoken_claims = self.kwargs.get("default_claims", None)
         lifetime = self.kwargs.get("lifetime")
 
         userinfo = userinfo_in_id_token_claims(

--- a/tests/test_24_authorization_endpoint.py
+++ b/tests/test_24_authorization_endpoint.py
@@ -806,13 +806,10 @@ class TestEndpoint(object):
 
 
 def test_inputs():
-    elems = inputs({"foo": "bar", "home": "stead"})
-    print(elems)
-    assert (
-            elems
-            == """<input type="hidden" name="foo" value="bar"/>
-<input type="hidden" name="home" value="stead"/>"""
-    )
+    elems = inputs(dict(foo = "bar", home = "stead"))
+    test_elems = ('<input type="hidden" name="foo" value="bar"/>',
+                  '<input type="hidden" name="home" value="stead"/>')
+    assert (test_elems[0] in elems and test_elems[1] in elems)
 
 
 def test_acr_claims():
@@ -827,4 +824,6 @@ def test_acr_claims():
 def test_join_query():
     redirect_uris = [("https://rp.example.com/cb", {"foo": ["bar"], "state": ["low"]})]
     uri = join_query(*redirect_uris[0])
-    assert uri == "https://rp.example.com/cb?foo=bar&state=low"
+    test_uri = ("https://rp.example.com/cb?", "foo=bar", "state=low")
+    for i in test_uri:
+        assert i in uri

--- a/tests/test_30_end_session.py
+++ b/tests/test_30_end_session.py
@@ -418,10 +418,11 @@ class TestEndpoint(object):
         _cdb["frontchannel_logout_session_required"] = True
         _cdb["client_id"] = "client_1"
         res = do_front_channel_logout_iframe(_cdb, ISS, "_sid_")
-        assert (
-            res
-            == '<iframe src="https://example.com/fc_logout?iss=https%3A%2F%2Fexample.com%2F&sid=_sid_">'
-        )
+        test_res = ('<iframe src="https://example.com/fc_logout?',
+                    'iss=https%3A%2F%2Fexample.com%2F',
+                    'sid=_sid_') 
+        for i in test_res:
+            assert (i in res)
 
     def test_front_channel_logout_with_query(self):
         self._code_auth("1234567")
@@ -431,10 +432,11 @@ class TestEndpoint(object):
         _cdb["frontchannel_logout_session_required"] = True
         _cdb["client_id"] = "client_1"
         res = do_front_channel_logout_iframe(_cdb, ISS, "_sid_")
-        assert (
-            res
-            == '<iframe src="https://example.com/fc_logout?entity_id=foo&iss=https%3A%2F%2Fexample.com%2F&sid=_sid_">'
-        )
+        test_res = ('<iframe', 'src="https://example.com/fc_logout?',
+                    'entity_id=foo',
+                    'iss=https%3A%2F%2Fexample.com%2F','sid=_sid_')
+        for i in test_res:
+            assert (i in res)
 
     def test_logout_from_client_bc(self):
         self._code_auth("1234567")


### PR DESCRIPTION
little things in endpoint_context.py

Fixed: tests/test_24_authorization_endpoint.py
Sometimes test_inputs fails for input elements order

I get in tests/test_26_userinfo_endpoint.py
ImportError: No module named 'oidcendpoint.oidc.add_on.custom_scopes'
and yes it's missing. Is it still to be committed?

Then test_30_end_session.py: got many failures.
Fixed some of them regarding url-args ordering but cookie with "wrong client" error
and another KeyError still need to be patched. 
