### PR TITLE
cookie dealer

### DIFF
--- a/src/oidcendpoint/cookie.py
+++ b/src/oidcendpoint/cookie.py
@@ -300,7 +300,10 @@ class CookieDealer(object):
             else:
                 self.sign_key = SYMKey(k=sign_key)
         elif sign_jwk:
-            self.sign_key = import_jwk(sign_jwk)
+            if isinstance(sign_jwk, dict):
+                self.sign_key = import_jwk(sign_jwk['filename'])
+            else:
+                self.sign_key = import_jwk(sign_jwk)
         else:
             self.sign_key = None
 
@@ -312,7 +315,10 @@ class CookieDealer(object):
             else:
                 self.enc_key = SYMKey(k=enc_key)
         elif enc_jwk:
-            self.enc_key = import_jwk(enc_jwk)
+            if isinstance(enc_jwk, dict):
+                self.enc_key = import_jwk(enc_jwk['filename'])
+            else:
+                self.enc_key = import_jwk(enc_jwk)
         else:
             self.enc_key = None
 

--- a/src/oidcendpoint/oidc/session.py
+++ b/src/oidcendpoint/oidc/session.py
@@ -381,11 +381,8 @@ class Session(Endpoint):
         else:
             _res = self.logout_from_client(sid=sid, client_id=client_id)
 
-        try:
-            bcl = _res["blu"]
-        except KeyError:
-            pass
-        else:
+        bcl = _res.get("blu")
+        if bcl:
             # take care of Back channel logout first
             for _cid, spec in bcl.items():
                 _url, sjwt = spec
@@ -402,10 +399,7 @@ class Session(Endpoint):
                 elif res.status_code >= 400:
                     logger.info("failed to logout from {}".format(_cid))
 
-        try:
-            return _res["flu"].values()
-        except KeyError:
-            return []
+        return _res["flu"].values() if _res.get("fluu") else []
 
     def kill_cookies(self):
         _ec = self.endpoint_context


### PR DESCRIPTION
just implemented a way to handle properly an old kind of configuration with static cookie definitions

It works with this:
````
    cookie_dealer:
      class: oidcendpoint.cookie.CookieDealer
      kwargs:
        sign_jwk:
          filename: data/oidc_op/private/cookie_sign_jwk.json
          sign_alg: 'SHA256'
          type: OCT
          kid: cookie_sign_key_id
        enc_jwk:
          ## otherwise do it yourself: jwkgen --kty SYM > data/oidc_op/private/cookie_enc_jwk.json
          filename: 'data/oidc_op/private/cookie_enc_jwk.json'
          type: OCT
          kid: cookie_enc_key_id

````

ans also with this

````
    cookie_dealer:
      class: oidcendpoint.cookie.CookieDealer
      kwargs:
        ## the manual one here...
        sign_jwk: data/oidc_op/private/cookie_sign_jwk.json
        sign_alg: 'SHA256'

        # ## jwkgen --kty SYM > data/oidc_op/private/cookie_enc_jwk.json
        enc_jwk: 'data/oidc_op/private/cookie_enc_jwk.json'
````