### PR TITLE
Fix bug, `add_claims_by_scope` was not used

### DIFF
--- a/src/oidcendpoint/jwt_token.py
+++ b/src/oidcendpoint/jwt_token.py
@@ -70,7 +70,7 @@ class JWTToken(Token):
 
         if "add_claims" in self.args:
             self.add_claims(payload, uinfo, self.args["add_claims"])
-        if "add_claims_by_scope":
+        if self.args.get("add_claims_by_scope", False):
             self.add_claims(
                 payload, uinfo,
                 scope2claims(sinfo["authn_req"]["scope"],


### PR DESCRIPTION
In JWTToken the `add_claims_by_scope` parameter was not used, now it defaults to False. 

IMO the default behaviour should be that if `add_claims_by_scope` is True then `scope_claims_map` defaults to the `scope2claims` dict found in endpoint_context. 
If you agree with that I can implement it.