### PR TITLE
Use the scope2claims dict in JWTToken

### DIFF
--- a/src/oidcendpoint/endpoint_context.py
+++ b/src/oidcendpoint/endpoint_context.py
@@ -122,6 +122,7 @@ class EndpointContext:
         self.login_hint_lookup = None
         self.login_hint2acrs = None
         self.userinfo = None
+        self.scope2claims = SCOPE2CLAIMS
         # arguments for endpoints add-ons
         self.args = {}
 
@@ -139,8 +140,6 @@ class EndpointContext:
             self.set_session_db(sso_db, db=session_db)
         else:
             self.set_session_db(sso_db)
-
-        self.scope2claims = SCOPE2CLAIMS
 
         if cookie_name:
             self.cookie_name = cookie_name

--- a/src/oidcendpoint/jwt_token.py
+++ b/src/oidcendpoint/jwt_token.py
@@ -34,10 +34,7 @@ class JWTToken(Token):
 
         self.def_aud = aud or []
         self.alg = alg
-        if 'scope_claims_map' in kwargs:
-            self.scope_claims_map = kwargs['scope_claims_map']
-        else:
-            self.scope_claims_map = None
+        self.scope_claims_map = kwargs.get('scope_claims_map', ec.scope2claims)
 
     def add_claims(self, payload, uinfo, claims):
         for attr in claims:


### PR DESCRIPTION
The scope_claims_map defaults to the endpoint_context's scope2claims
dict (as discussed in #29)