### PR TITLE
Fix token introspection endpoint responses

### DIFF
--- a/src/oidcendpoint/oauth2/introspection.py
+++ b/src/oidcendpoint/oauth2/introspection.py
@@ -40,19 +40,20 @@ class Introspection(Endpoint):
         :return:
         """
         _introspect_request = self.request_cls(**request)
+        _resp = self.response_cls(active=False)
 
         _jwt = JWT(key_jar=self.endpoint_context.keyjar)
 
         try:
             _jwt_info = _jwt.unpack(_introspect_request["token"])
         except Exception:
-            return {"response": {"active": False}}
+            return {"response_args": _resp}
 
         # expired ?
         if "exp" in _jwt_info:
             now = utc_time_sans_frac()
             if _jwt_info["exp"] < now:
-                return {"response": {"active": False}}
+                return {"response_args": _resp}
 
         if "release" in self.kwargs:
             if "username" in self.kwargs["release"]:
@@ -61,9 +62,9 @@ class Introspection(Endpoint):
                         sub=_jwt_info["sub"]
                     )
                 except KeyError:
-                    return {"response": {"active": False}}
+                    return {"response_args": _resp}
 
-        _resp = self.response_cls(**_jwt_info)
+        _resp.update(_jwt_info)
         _resp.weed()
         _resp["active"] = True
 


### PR DESCRIPTION
The response object should return a TokenIntrospectionResponse
object argument in all cases (if the request is valid).

Meant to solve #31.