### PR TITLE
Copy default_claims dict to make an id_token

### DIFF
--- a/src/oidcendpoint/id_token.py
+++ b/src/oidcendpoint/id_token.py
@@ -251,7 +251,7 @@ class IDToken(object):
 
         _cinfo = _context.cdb[_client_id]
 
-        default_idtoken_claims = self.kwargs.get("default_claims", None)
+        default_idtoken_claims = dict(self.kwargs.get("default_claims", {}))
         lifetime = self.kwargs.get("lifetime")
 
         userinfo = userinfo_in_id_token_claims(


### PR DESCRIPTION
When creating an id token the default_claims dictionary defined in the configurations is used and updated, this resulted in the unexpected behaviour defined below.

The id token class https://github.com/IdentityPython/oidcendpoint/blob/master/src/oidcendpoint/id_token.py#L105) is configured to have a default_claims dict, which contains claims that will be added to every id token. This dict is updated every time an authn request is made (in https://github.com/IdentityPython/oidcendpoint/blob/master/src/oidcendpoint/userinfo.py#L186). 

This results in a bug which can be easily seen in the following case:
The IDToken's class default_claims is:
```
{
  "email_verified": {"essential": True}
}
```
An authorization request is done with `claims={'id_token': {'email': None}}`, then the IDToken's class default_claims will be altered to:
```
{
  'email': None,
  'email_verified': {'essential': True}
}
```
So any id tokens created after will contain both the `email` and the `email_verified` claims (even if `email` is not in the scope nor requested).

This pull request fixes this bug by copying the default_claims dict instead of directly using it.