### PR TITLE
Fix introspection endpoint's advertised name

### DIFF
--- a/src/oidcendpoint/oauth2/introspection.py
+++ b/src/oidcendpoint/oauth2/introspection.py
@@ -17,7 +17,7 @@ class Introspection(Endpoint):
     response_cls = oauth2.TokenIntrospectionResponse
     request_format = "urlencoded"
     response_format = "json"
-    endpoint_name = "introspection"
+    endpoint_name = "introspection_endpoint"
     name = "introspection"
 
     def get_client_id_from_token(self, endpoint_context, token, request=None):


### PR DESCRIPTION
According to https://tools.ietf.org/html/draft-ietf-oauth-discovery-06#page-6 the introspection endpoint should be advertised under `introspection_endpoint`, not `introspection`.