### PR TITLE
Add claims per client in id token

### DIFF
--- a/src/oidcendpoint/id_token.py
+++ b/src/oidcendpoint/id_token.py
@@ -112,6 +112,7 @@ class IDToken(object):
     def __init__(self, endpoint_context, **kwargs):
         self.endpoint_context = endpoint_context
         self.kwargs = kwargs
+        self.enable_claims_per_client = kwargs.get('enable_claims_per_client')
         self.scope_to_claims = None
         self.provider_info = construct_endpoint_info(
             self.default_capabilities, **kwargs
@@ -250,10 +251,9 @@ class IDToken(object):
 
         _cinfo = _context.cdb[_client_id]
 
-        idtoken_claims = dict(
-            self.kwargs.get("default_claims", {}),
-            **_cinfo.get("id_token_claims", {})
-        )
+        idtoken_claims = dict(self.kwargs.get("default_claims", {}))
+        if self.enable_claims_per_client:
+            idtoken_claims.update(_cinfo.get("id_token_claims", {}))
         lifetime = self.kwargs.get("lifetime")
 
         userinfo = userinfo_in_id_token_claims(

--- a/src/oidcendpoint/id_token.py
+++ b/src/oidcendpoint/id_token.py
@@ -242,7 +242,6 @@ class IDToken(object):
 
     def make(self, req, sess_info, authn_req=None, user_claims=False, **kwargs):
         _context = self.endpoint_context
-        _sdb = _context.sdb
 
         if authn_req:
             _client_id = authn_req["client_id"]
@@ -251,11 +250,14 @@ class IDToken(object):
 
         _cinfo = _context.cdb[_client_id]
 
-        default_idtoken_claims = dict(self.kwargs.get("default_claims", {}))
+        idtoken_claims = dict(
+            self.kwargs.get("default_claims", {}),
+            **_cinfo.get("id_token_claims", {})
+        )
         lifetime = self.kwargs.get("lifetime")
 
         userinfo = userinfo_in_id_token_claims(
-            _context, sess_info, default_idtoken_claims
+            _context, sess_info, idtoken_claims
         )
 
         if user_claims:

--- a/src/oidcendpoint/id_token.py
+++ b/src/oidcendpoint/id_token.py
@@ -112,7 +112,9 @@ class IDToken(object):
     def __init__(self, endpoint_context, **kwargs):
         self.endpoint_context = endpoint_context
         self.kwargs = kwargs
-        self.enable_claims_per_client = kwargs.get('enable_claims_per_client')
+        self.enable_claims_per_client = kwargs.get(
+            'enable_claims_per_client', False
+        )
         self.scope_to_claims = None
         self.provider_info = construct_endpoint_info(
             self.default_capabilities, **kwargs

--- a/tests/test_03_id_token.py
+++ b/tests/test_03_id_token.py
@@ -355,6 +355,7 @@ class TestEndpoint(object):
         assert "nickname" in res
 
     def test_client_claims_disabled(self):
+        # enable_claims_per_client defaults to False
         session_info = {
             "authn_req": AREQN,
             "sub": "sub",


### PR DESCRIPTION
Adds the `id_token_claims` to clients, which is used to add specific claims per client to the id token.

This would give the ability to the clients to choose any set of claims they want when the registration endpoint is activated, but they would be able to do that nonetheless by using the claims parameter. Maybe we should add an option to limit the claims that can be included in an id token(e.g. "allowed_claims")? 