### PR TITLE
Add claims per client in access token

### DIFF
--- a/src/oidcendpoint/session.py
+++ b/src/oidcendpoint/session.py
@@ -302,14 +302,15 @@ class SessionDB(object):
 
     def _make_at(self, sid, session_info, aud=None, client_id_aud=True):
         uid = self.sso_db.get_uid_by_sid(sid)
-
-        uinfo = self.userinfo(uid, session_info["client_id"]) or {}
+        client_id = session_info["client_id"]
+        uinfo = self.userinfo(uid, client_id) or {}
         at_aud = aud or []
 
         if client_id_aud:
-            at_aud.append(session_info["client_id"])
+            at_aud.append(client_id)
         return self.handler["access_token"](
-            sid=sid, sinfo=session_info, uinfo=uinfo, aud=at_aud
+            sid=sid, sinfo=session_info, uinfo=uinfo, aud=at_aud,
+            client_id=client_id
         )
 
     def upgrade_to_token(

--- a/tests/test_27_jwt_token.py
+++ b/tests/test_27_jwt_token.py
@@ -189,6 +189,24 @@ class TestEndpoint(object):
         assert _info["type"] == "T"
         assert _info["sid"] == session_id
 
+    @pytest.mark.parametrize("enable_claims_per_client", [True, False])
+    def test_client_claims(self, enable_claims_per_client):
+        ec = self.endpoint.endpoint_context
+        handler = ec.sdb.handler.handler["access_token"]
+        session_id = setup_session(
+            ec, AUTH_REQ, uid="diana"
+        )
+        ec.cdb["client_1"]['access_token_claims'] = {
+            "address": None
+        }
+        handler.enable_claims_per_client = enable_claims_per_client
+        _dic = ec.sdb.upgrade_to_token(key=session_id)
+
+        token = _dic["access_token"]
+        _jwt = JWT(key_jar=KEYJAR, iss="client_1")
+        res = _jwt.unpack(token)
+        assert enable_claims_per_client is ("address" in res)
+
     def test_is_expired(self):
         session_id = setup_session(
             self.endpoint.endpoint_context, AUTH_REQ, uid="diana"


### PR DESCRIPTION
Adds the `access_token_claims` to clients, which is used to add specific claims per client to the access token.