### PR TITLE
Initialize client database before the token handlers

### DIFF
--- a/src/oidcendpoint/endpoint_context.py
+++ b/src/oidcendpoint/endpoint_context.py
@@ -146,10 +146,12 @@ class EndpointContext:
             except KeyError:
                 pass
 
-        self.th_args = get_token_handlers(conf)
-
         # client database
+        # Initialize cdb before the token handlers since the JWT token handler
+        # might need it
         self.set_client_db()
+
+        self.th_args = get_token_handlers(conf)
 
         # session db
         self._sub_func = {}

--- a/src/oidcendpoint/jwt_token.py
+++ b/src/oidcendpoint/jwt_token.py
@@ -24,6 +24,7 @@ class JWTToken(Token):
         typ,
         keyjar=None,
         issuer=None,
+        cdb=None,
         aud=None,
         alg="ES256",
         lifetime=300,
@@ -38,7 +39,7 @@ class JWTToken(Token):
 
         self.key_jar = keyjar or ec.keyjar
         self.issuer = issuer or ec.issuer
-        self.cdb = ec.cdb
+        self.cdb = cdb or ec.cdb
 
         self.def_aud = aud or []
         self.alg = alg


### PR DESCRIPTION
Initialize the client database before the token handlers since the JWT token handler might need it