### PR TITLE
Add extra_claims_supported option

### DIFF
--- a/src/oidcendpoint/endpoint_context.py
+++ b/src/oidcendpoint/endpoint_context.py
@@ -399,6 +399,10 @@ class EndpointContext:
         _claims = set()
         for scope, claims in self.scope2claims.items():
             _claims.update(set(claims))
+
+        extra_claims = self.conf.get("extra_claims_supported")
+        if extra_claims:
+            _claims.update(set(extra_claims))
         return list(_claims)
 
     def create_providerinfo(self, capabilities):

--- a/tests/test_00_endpoint_context.py
+++ b/tests/test_00_endpoint_context.py
@@ -152,3 +152,12 @@ def test_cdb():
     endpoint_context.cdb = _clients["oidc_clients"]
 
     assert set(endpoint_context.cdb.keys()) == {"client1", "client2", "client3"}
+
+
+def test_extra_claims_supported():
+    _cnf = copy(conf)
+    _cnf["extra_claims_supported"] = ["aba", "douba"]
+    endpoint_context = EndpointContext(_cnf)
+
+    assert "aba" in endpoint_context.provider_info["claims_supported"]
+    assert "douba" in endpoint_context.provider_info["claims_supported"]


### PR DESCRIPTION
The only way to configure the claims_supported parameter was through the
scopes_supported option, but someone might want to use claims that don't
correspond to some scope.
The extra_claims_supported option solves this problem.