### PR TITLE
ABStorage: Fixed del key on SessionDB

### DIFF
--- a/src/oidcendpoint/session.py
+++ b/src/oidcendpoint/session.py
@@ -163,7 +163,7 @@ class SessionDB(object):
         self._db.set(sid, _info)
 
     def __delitem__(self, key):
-        self._db.delete(key)
+        del self._db[key]
 
     def keys(self):
         return self._db.keys()


### PR DESCRIPTION
del takes only a key value
.delete() takes key and value

this fixes the tests with example configurations