### PR TITLE
Fix bug in introspection

### DIFF
--- a/src/oidcendpoint/oauth2/introspection.py
+++ b/src/oidcendpoint/oauth2/introspection.py
@@ -60,7 +60,7 @@ class Introspection(Endpoint):
             return None
 
         # Make sure that the token is an access_token or a refresh_token
-        if token not in info.get("access_token") and token != info.get("refresh_token"):
+        if token != info.get("access_token") and token != info.get("refresh_token"):
             return None
 
         eat = info.get("expires_at")

--- a/tests/test_31_introspection.py
+++ b/tests/test_31_introspection.py
@@ -302,6 +302,25 @@ class TestEndpoint:
         assert _resp_args["active"]
         assert _resp_args["scope"] == "openid"
 
+    def test_code(self):
+        _context = self.introspection_endpoint.endpoint_context
+
+        session_id = setup_session(
+            _context, AUTH_REQ, uid="A", acr=INTERNETPROTOCOLPASSWORD,
+        )
+        code = _context.sdb[session_id]["code"]
+
+        _req = self.introspection_endpoint.parse_request(
+            {
+                "token": code,
+                "client_id": "client_1",
+                "client_secret": _context.cdb["client_1"]["client_secret"],
+            }
+        )
+        _resp = self.introspection_endpoint.process_request(_req)
+        _resp_args = _resp["response_args"]
+        assert _resp_args["active"] is False
+
     def test_introspection_claims(self):
         self.introspection_endpoint.enable_claims_per_client = True
         _context = self.introspection_endpoint.endpoint_context


### PR DESCRIPTION
If a code was provided in  the token endpoint (instead of an access/refresh token), then it would result in an Exception, because `info.get("access_token") = None` and `token in None` raises:
`TypeError: argument of type 'NoneType' is not iterable`