### PR TITLE
Remove call to map_kv2sid

### DIFF
--- a/src/oidcendpoint/oidc/session.py
+++ b/src/oidcendpoint/oidc/session.py
@@ -123,11 +123,8 @@ class Session(Endpoint):
         _sdb = self.endpoint_context.sdb
         _sso_db = self.endpoint_context.sdb.sso_db
         for sid in usids:
-            _state = _sdb[sid]["authn_req"]["state"]
             # remove session information
             del _sdb[sid]
-            # remove all states connected to this session id
-            _sdb.delete_kv2sid(_state, "state")
             _sso_db.remove_session_id(sid)
 
     def logout_all_clients(self, sid, client_id):

--- a/src/oidcendpoint/session.py
+++ b/src/oidcendpoint/session.py
@@ -203,7 +203,6 @@ class SessionDB(object):
 
         if areq:
             _info["authn_req"] = areq
-            self.map_kv2sid(areq["state"], "state", sid)
         if authn_event:
             _info["authn_event"] = authn_event
 

--- a/tests/test_33_pkce.py
+++ b/tests/test_33_pkce.py
@@ -238,10 +238,7 @@ class TestEndpoint(object):
         assert isinstance(resp["response_args"], AuthorizationResponse)
 
         _token_request = TOKEN_REQ.copy()
-        session = self.token_endpoint.endpoint_context.sdb[
-            resp["response_args"]["code"]
-        ]
-        _token_request["code"] = session["code"]
+        _token_request["code"] = resp["response_args"]["code"]
         _token_request["code_verifier"] = _cc_info["code_verifier"]
         _req = self.token_endpoint.parse_request(_token_request)
 


### PR DESCRIPTION
State can't be assumed to be unique since the client chooses it, so we
can't use it as an identifier for getting the sid

In general I don't think don't see a use case for the `map_kv2sid` function.