### PR TITLE
Feature client authn

### DIFF
--- a/src/oidcendpoint/client_authn.py
+++ b/src/oidcendpoint/client_authn.py
@@ -430,13 +430,19 @@ def client_auth_setup(auth_set, endpoint_context):
     res = []
 
     for item in auth_set:
-        if item is None or item.lower() == "none":
+        if item is None or (isinstance(item, str) and item.lower() == "none"):
             res.append(None)
         else:
-            _cls = CLIENT_AUTHN_METHOD.get(item)
-            if _cls:
-                res.append(_cls(endpoint_context))
+            if isinstance(item, dict):
+                module = item.get("class")
+                kwargs = item.get("kwargs")
             else:
-                res.append(importer(item)(endpoint_context))
+                # For backwards compatibility
+                module = item
+                kwargs = {}
+            _cls = CLIENT_AUTHN_METHOD.get(module)
+            if not _cls:
+                _cls = importer(module)
+            res.append(_cls(endpoint_context, **kwargs))
 
     return res

--- a/src/oidcendpoint/util.py
+++ b/src/oidcendpoint/util.py
@@ -17,12 +17,12 @@ def modsplit(s):
     if ":" in s:
         c = s.split(":")
         if len(c) != 2:
-            raise ValueError("Syntax error: {s}")
+            raise ValueError(f"Syntax error: {s}")
         return c[0], c[1]
     else:
         c = s.split(".")
         if len(c) < 2:
-            raise ValueError("Syntax error: {s}")
+            raise ValueError(f"Syntax error: {s}")
         return ".".join(c[:-1]), c[-1]
 
 


### PR DESCRIPTION
Refactor `client_auth_setup` to give the option to the user to provide kwargs that
will be used for initializing the provided class.

The old configuration is still supported.
Then new configuration is in the format:
```
class: path.to.class
kwargs: 
    a: 1
    b: 2
    c: 3
```
kwargs is optional