### PR TITLE
Cookie is not mandatory, disabled dependencies

### DIFF
--- a/src/oidcendpoint/oidc/session.py
+++ b/src/oidcendpoint/oidc/session.py
@@ -238,7 +238,7 @@ class Session(Endpoint):
             )
         except IndexError:
             raise InvalidRequest("Cookie error")
-        except KeyError:
+        except (KeyError, AttributeError):
             part = None
 
         if part:

--- a/src/oidcendpoint/user_authn/user.py
+++ b/src/oidcendpoint/user_authn/user.py
@@ -76,7 +76,7 @@ class UserAuthnMethod(object):
                 val = self.cookie_dealer.get_cookie_value(
                     cookie, cookie_name=self.endpoint_context.cookie_name["session"]
                 )
-            except (InvalidCookieSign, AssertionError) as err:
+            except (InvalidCookieSign, AssertionError, AttributeError) as err:
                 logger.warning(err)
                 val = None
 


### PR DESCRIPTION
in django-oidc-op I disabled cookies (OP side).
This changements let users to not configure any cookie handlers in oidcendpoint.
In addition it seems also to work :)