### PR TITLE
[Policy] Authz and Userinfo filter on unallowed scope

### DIFF
--- a/src/oidcendpoint/exception.py
+++ b/src/oidcendpoint/exception.py
@@ -66,6 +66,10 @@ class UnAuthorizedClient(OidcEndpointError):
     pass
 
 
+class UnAuthorizedClientScope(OidcEndpointError):
+    pass
+
+
 class InvalidCookieSign(Exception):
     pass
 

--- a/src/oidcendpoint/userinfo.py
+++ b/src/oidcendpoint/userinfo.py
@@ -157,6 +157,9 @@ def collect_user_info(
             logger.debug("userinfo_claim: %s" % sanitize(userinfo_claims.to_dict()))
         else:
             userinfo_claims = None
+            logger.warning('Client {} UnAllowed to access to Userinfo endpoint')
+            raise FailedAuthentication("UnAllowed to access to Userinfo endpoint: "
+                                       "invalid scope.")
 
     logger.debug("Session info: %s" % sanitize(session))
 


### PR DESCRIPTION
This PR introduce a filter regarding the scope that would have been released to a RP.
If by a side it could sound a bit pendantic by other side we should face the need to put all the security checks in a way that using a different RP from oidcrp would give by the way a good posture.

As discussed here:
https://github.com/IdentityPython/oidcendpoint/issues/73