### PR TITLE
Change userinfo's parse_request error

### DIFF
--- a/src/oidcendpoint/oidc/userinfo.py
+++ b/src/oidcendpoint/oidc/userinfo.py
@@ -148,7 +148,9 @@ class UserInfo(Endpoint):
                 request, auth, endpoint="userinfo", **kwargs
             )
         except ValueError as e:
-            return dict(error="invalid_token", error_description=e.args[0])
+            return self.error_cls(
+                error="invalid_token", error_description=e.args[0]
+            )
 
         if isinstance(auth_info, ResponseMessage):
             return auth_info

--- a/tests/test_26_oidc_userinfo_endpoint.py
+++ b/tests/test_26_oidc_userinfo_endpoint.py
@@ -218,7 +218,7 @@ class TestEndpoint(object):
             {}, auth="Bearer invalid"
         )
 
-        assert _req == {
+        assert _req.to_dict() == {
             "error": "invalid_token", "error_description": "Unknown token"
         }
 


### PR DESCRIPTION
parse_request should return a response-type object and not a dict in
order to be consistent with the rest of the endpoints.

Related to #76.