### PR TITLE
Feature pkce errors

### DIFF
--- a/src/oidcendpoint/endpoint.py
+++ b/src/oidcendpoint/endpoint.py
@@ -309,6 +309,8 @@ class Endpoint(object):
 
     def do_post_parse_request(self, request, client_id="", **kwargs):
         for meth in self.post_parse_request:
+            if isinstance(request, self.error_cls):
+                break
             request = meth(
                 request, client_id, endpoint_context=self.endpoint_context, **kwargs
             )

--- a/src/oidcendpoint/endpoint.py
+++ b/src/oidcendpoint/endpoint.py
@@ -312,9 +312,6 @@ class Endpoint(object):
             request = meth(
                 request, client_id, endpoint_context=self.endpoint_context, **kwargs
             )
-            if isinstance(request, AuthorizationErrorResponse):
-                LOGGER.error(request.to_json())
-                raise UnAuthorizedClient(request.to_dict())
         return request
 
     def do_pre_construct(self, response_args, request, **kwargs):

--- a/src/oidcendpoint/oauth2/authorization.py
+++ b/src/oidcendpoint/oauth2/authorization.py
@@ -9,8 +9,6 @@ from cryptojwt.utils import b64d
 from cryptojwt.utils import b64e
 from oidcmsg import oauth2
 from oidcmsg.exception import ParameterError
-from oidcmsg.oauth2 import AuthorizationErrorResponse
-from oidcmsg.oauth2 import AuthorizationRequest
 from oidcmsg.oidc import AuthorizationResponse
 from oidcmsg.oidc import verified_claim_name
 
@@ -34,69 +32,10 @@ from oidcendpoint.exception import ServiceError
 from oidcendpoint.exception import TamperAllert
 from oidcendpoint.exception import ToOld
 from oidcendpoint.exception import UnknownClient
-from oidcendpoint.scopes import available_scopes
 from oidcendpoint.session import setup_session
 from oidcendpoint.user_authn.authn_context import pick_auth
 
 logger = logging.getLogger(__name__)
-
-
-def create_authn_response(endpoint, request, sid):
-    """
-
-    :param endpoint:
-    :param request:
-    :param sid:
-    :return:
-    """
-    # create the response
-    aresp = AuthorizationResponse()
-    if request.get("state"):
-        aresp["state"] = request["state"]
-
-    if "response_type" in request and request["response_type"] == ["none"]:
-        fragment_enc = False
-    else:
-        _context = endpoint.endpoint_context
-        _sinfo = _context.sdb[sid]
-
-        if request.get("scope"):
-            aresp["scope"] = request["scope"]
-
-        rtype = set(request["response_type"][:])
-        handled_response_type = []
-
-        fragment_enc = True
-        if len(rtype) == 1 and "code" in rtype:
-            fragment_enc = False
-
-        if "code" in request["response_type"]:
-            _code = aresp["code"] = _context.sdb[sid]["code"]
-            handled_response_type.append("code")
-        else:
-            _context.sdb.update(sid, code=None)
-            _code = None
-
-        if "token" in rtype:
-            _dic = _context.sdb.upgrade_to_token(issue_refresh=False, key=sid)
-
-            logger.debug("_dic: %s" % sanitize(_dic))
-            for key, val in _dic.items():
-                if key in aresp.parameters() and val is not None:
-                    aresp[key] = val
-
-            handled_response_type.append("token")
-
-        _access_token = aresp.get("access_token", None)
-
-        not_handled = rtype.difference(handled_response_type)
-        if not_handled:
-            resp = AuthorizationErrorResponse(
-                error="invalid_request", error_description="unsupported_response_type"
-            )
-            return {"response_args": resp, "fragment_enc": fragment_enc}
-
-    return {"response_args": aresp, "fragment_enc": fragment_enc}
 
 
 # For the time being. This is JAR specific and should probably be configurable.
@@ -123,6 +62,7 @@ def re_authenticate(request, authn):
 class Authorization(Endpoint):
     request_cls = oauth2.AuthorizationRequest
     response_cls = oauth2.AuthorizationResponse
+    error_cls = oauth2.AuthorizationErrorResponse
     request_format = "urlencoded"
     response_format = "urlencoded"
     response_placement = "url"
@@ -195,7 +135,7 @@ class Authorization(Endpoint):
             )
             if _resp.status_code == 200:
                 args = {"keyjar": endpoint_context.keyjar}
-                request = AuthorizationRequest().from_jwt(_resp.text, **args)
+                request = self.request_cls().from_jwt(_resp.text, **args)
                 self.allowed_request_algorithms(
                     client_id,
                     endpoint_context,
@@ -233,7 +173,7 @@ class Authorization(Endpoint):
         """
         if not request:
             logger.debug("No AuthzRequest")
-            return AuthorizationErrorResponse(
+            return self.error_cls(
                 error="invalid_request", error_description="Can not parse AuthzRequest"
             )
 
@@ -244,13 +184,13 @@ class Authorization(Endpoint):
             logger.error(
                 "Client ID ({}) not in client database".format(request["client_id"])
             )
-            return AuthorizationErrorResponse(
+            return self.error_cls(
                 error="unauthorized_client", error_description="unknown client"
             )
 
         # Is the asked for response_type among those that are permitted
         if not self.verify_response_type(request, _cinfo):
-            return AuthorizationErrorResponse(
+            return self.error_cls(
                 error="invalid_request",
                 error_description="Trying to use unregistered response_type",
             )
@@ -259,7 +199,7 @@ class Authorization(Endpoint):
         try:
             redirect_uri = get_uri(endpoint_context, request, "redirect_uri")
         except (RedirectURIError, ParameterError, UnknownClient) as err:
-            return AuthorizationErrorResponse(
+            return self.error_cls(
                 error="invalid_request",
                 error_description="{}: {}".format(err.__class__.__name__, err),
             )
@@ -388,6 +328,63 @@ class Authorization(Endpoint):
 
         return {"authn_event": authn_event, "identity": identity, "user": user}
 
+    def create_authn_response(self, request, sid):
+        """
+
+        :param self:
+        :param request:
+        :param sid:
+        :return:
+        """
+        # create the response
+        aresp = AuthorizationResponse()
+        if request.get("state"):
+            aresp["state"] = request["state"]
+
+        if "response_type" in request and request["response_type"] == ["none"]:
+            fragment_enc = False
+        else:
+            _context = self.endpoint_context
+            _sinfo = _context.sdb[sid]
+
+            if request.get("scope"):
+                aresp["scope"] = request["scope"]
+
+            rtype = set(request["response_type"][:])
+            handled_response_type = []
+
+            fragment_enc = True
+            if len(rtype) == 1 and "code" in rtype:
+                fragment_enc = False
+
+            if "code" in request["response_type"]:
+                _code = aresp["code"] = _context.sdb[sid]["code"]
+                handled_response_type.append("code")
+            else:
+                _context.sdb.update(sid, code=None)
+                _code = None
+
+            if "token" in rtype:
+                _dic = _context.sdb.upgrade_to_token(issue_refresh=False, key=sid)
+
+                logger.debug("_dic: %s" % sanitize(_dic))
+                for key, val in _dic.items():
+                    if key in aresp.parameters() and val is not None:
+                        aresp[key] = val
+
+                handled_response_type.append("token")
+
+            _access_token = aresp.get("access_token", None)
+
+            not_handled = rtype.difference(handled_response_type)
+            if not_handled:
+                resp = self.error_cls(
+                    error="invalid_request", error_description="unsupported_response_type"
+                )
+                return {"response_args": resp, "fragment_enc": fragment_enc}
+
+        return {"response_args": aresp, "fragment_enc": fragment_enc}
+
     def aresp_check(self, aresp, request):
         return ""
 
@@ -422,7 +419,7 @@ class Authorization(Endpoint):
         return kwargs
 
     def error_response(self, response_info, error, error_description):
-        resp = AuthorizationErrorResponse(
+        resp = self.error_cls(
             error=error, error_description=error_description
         )
         response_info["response_args"] = resp
@@ -471,7 +468,7 @@ class Authorization(Endpoint):
                 response_info, "access_denied", "Session is revoked"
             )
 
-        response_info = create_authn_response(self, request, sid)
+        response_info = self.create_authn_response(request, sid)
 
         try:
             redirect_uri = get_uri(self.endpoint_context, request, "redirect_uri")
@@ -585,7 +582,7 @@ class Authorization(Endpoint):
         :return: dictionary
         """
 
-        if isinstance(request_info, AuthorizationErrorResponse):
+        if isinstance(request_info, self.error_cls):
             return request_info
 
         _cid = request_info["client_id"]

--- a/src/oidcendpoint/oidc/add_on/pkce.py
+++ b/src/oidcendpoint/oidc/add_on/pkce.py
@@ -7,7 +7,22 @@ from oidcmsg.oidc import TokenErrorResponse
 
 LOGGER = logging.getLogger(__name__)
 
-CC_METHOD = {"S256": hashlib.sha256, "S384": hashlib.sha384, "S512": hashlib.sha512}
+
+def hash_fun(f):
+    def wrapper(code_verifier):
+        _h = f(code_verifier.encode("ascii")).digest()
+        _cc = b64e(_h)
+        return _cc.decode("ascii")
+
+    return wrapper
+
+
+CC_METHOD = {
+    "plain": lambda x: x,
+    "S256": hash_fun(hashlib.sha256),
+    "S384": hash_fun(hashlib.sha384),
+    "S512": hash_fun(hashlib.sha512),
+}
 
 
 def post_authn_parse(request, client_id, endpoint_context, **kwargs):
@@ -22,37 +37,35 @@ def post_authn_parse(request, client_id, endpoint_context, **kwargs):
     if isinstance(request, AuthorizationErrorResponse):
         return request
 
-    if endpoint_context.args["pkce"]["essential"] is True:
-        if "code_challenge" not in request:
-            return AuthorizationErrorResponse(
-                error="invalid_request",
-                error_description="Missing required code_challenge"
-            )
-        if "code_challenge_method" not in request:
-            if "plain" not in endpoint_context.args["pkce"]["code_challenge_method"]:
-                return AuthorizationErrorResponse(
-                    error="invalid_request",
-                    error_description="No support for code_challenge_method=plain"
-                )
+    if (
+        endpoint_context.args["pkce"]["essential"]
+        and "code_challenge" not in request
+    ):
+        return AuthorizationErrorResponse(
+            error="invalid_request",
+            error_description="Missing required code_challenge",
+        )
 
-            request["code_challenge_method"] = "plain"
-    else:  # May or may not
-        if "code_challenge" in request:
-            if "code_challenge_method" not in request:
-                if (
-                    "plain"
-                    not in endpoint_context.args["pkce"]["code_challenge_method"]
-                ):
-                    return AuthorizationErrorResponse(
-                        error="invalid_request",
-                        error_description="No support for code_challenge_method=plain"
-                    )
+    if "code_challenge_method" not in request:
+        request["code_challenge_method"] = "plain"
 
-                request["code_challenge_method"] = "plain"
+    if (
+        request["code_challenge_method"]
+        not in endpoint_context.args["pkce"]["code_challenge_methods"]
+    ):
+        return AuthorizationErrorResponse(
+            error="invalid_request",
+            error_description="Unsupported code_challenge_method={}".format(
+                request["code_challenge_method"]
+            ),
+        )
+
     return request
 
 
-def verify_code_challenge(code_verifier, code_challenge, code_challenge_method="S256"):
+def verify_code_challenge(
+    code_verifier, code_challenge, code_challenge_method="S256"
+):
     """
     Verify a PKCE (RFC7636) code challenge.
 
@@ -61,16 +74,12 @@ def verify_code_challenge(code_verifier, code_challenge, code_challenge_method="
     :param code_challenge: The transformed verifier used as challenge
     :return:
     """
-    _h = CC_METHOD[code_challenge_method](code_verifier.encode("ascii")).digest()
-    _cc = b64e(_h)
-    if _cc.decode("ascii") != code_challenge:
+    if CC_METHOD[code_challenge_method](code_verifier) != code_challenge:
         LOGGER.error("PKCE Code Challenge check failed")
-        return TokenErrorResponse(
-            error="invalid_grant",
-            error_description="PKCE check failed"
-        )
+        return False
 
     LOGGER.debug("PKCE Code Challenge check succeeded")
+    return True
 
 
 def post_token_parse(request, client_id, endpoint_context, **kwargs):
@@ -83,29 +92,30 @@ def post_token_parse(request, client_id, endpoint_context, **kwargs):
     if isinstance(request, AuthorizationErrorResponse):
         return request
 
-    if "code_verifier" in request:
-        try:
-            _info = endpoint_context.sdb[request["code"]]
-        except KeyError:
+    try:
+        _info = endpoint_context.sdb[request["code"]]
+    except KeyError:
+        return TokenErrorResponse(
+            error="invalid_grant", error_description="Unknown access grant"
+        )
+    _authn_req = _info["authn_req"]
+
+    if "code_challenge" in _authn_req:
+        if "code_verifier" not in request:
             return TokenErrorResponse(
                 error="invalid_grant",
-                error_description="Unknown access grant"
+                error_description="Missing code_verifier",
             )
 
-        _authn_req = _info["authn_req"]
-        if "code_challenge" in _authn_req:
-            try:
-                _method = _info["authn_req"]["code_challenge_method"]
-            except KeyError:
-                _method = "S256"
+        _method = _info["authn_req"]["code_challenge_method"]
 
-            verify_code_challenge(
-                request["code_verifier"], _info["authn_req"]["code_challenge"], _method
-            )
-        else:
+        if not verify_code_challenge(
+            request["code_verifier"],
+            _info["authn_req"]["code_challenge"],
+            _method,
+        ):
             return TokenErrorResponse(
-                error="invalid_grant",
-                error_description="Missing code_challenge in authorization request"
+                error="invalid_grant", error_description="PKCE check failed"
             )
 
     return request
@@ -114,11 +124,18 @@ def post_token_parse(request, client_id, endpoint_context, **kwargs):
 def add_pkce_support(endpoint, **kwargs):
     endpoint["authorization"].post_parse_request.append(post_authn_parse)
 
-    # Set defaults
     if "essential" not in kwargs:
         kwargs["essential"] = False
-    if "code_challenge" not in kwargs:
-        kwargs["code_challenge"] = list(CC_METHOD.keys())
+
+    code_challenge_methods = kwargs.get(
+        "code_challenge_methods", CC_METHOD.keys()
+    )
+
+    kwargs["code_challenge_methods"] = {}
+    for method in code_challenge_methods:
+        if method not in CC_METHOD:
+            raise ValueError("Unsupported method: {}".format(method))
+        kwargs["code_challenge_methods"][method] = CC_METHOD[method]
 
     endpoint["authorization"].endpoint_context.args["pkce"] = kwargs
 

--- a/src/oidcendpoint/oidc/add_on/pkce.py
+++ b/src/oidcendpoint/oidc/add_on/pkce.py
@@ -34,9 +34,6 @@ def post_authn_parse(request, client_id, endpoint_context, **kwargs):
     :param kwargs:
     :return:
     """
-    if isinstance(request, AuthorizationErrorResponse):
-        return request
-
     if (
         endpoint_context.args["pkce"]["essential"]
         and "code_challenge" not in request

--- a/src/oidcendpoint/oidc/add_on/pkce.py
+++ b/src/oidcendpoint/oidc/add_on/pkce.py
@@ -67,7 +67,7 @@ def verify_code_challenge(code_verifier, code_challenge, code_challenge_method="
         LOGGER.error("PKCE Code Challenge check failed")
         return TokenErrorResponse(
             error="invalid_grant",
-            error_description="PCKE check failed"
+            error_description="PKCE check failed"
         )
 
     LOGGER.debug("PKCE Code Challenge check succeeded")

--- a/src/oidcendpoint/oidc/authorization.py
+++ b/src/oidcendpoint/oidc/authorization.py
@@ -11,9 +11,6 @@ from cryptojwt.utils import b64d
 from cryptojwt.utils import b64e
 from oidcmsg import oidc
 from oidcmsg.exception import ParameterError
-from oidcmsg.oauth2 import AuthorizationErrorResponse
-from oidcmsg.oauth2 import AuthorizationRequest
-from oidcmsg.oidc import AuthorizationResponse
 from oidcmsg.oidc import Claims
 from oidcmsg.oidc import verified_claim_name
 
@@ -41,90 +38,6 @@ from oidcendpoint.session import setup_session
 from oidcendpoint.user_authn.authn_context import pick_auth
 
 logger = logging.getLogger(__name__)
-
-
-def create_authn_response(endpoint, request, sid):
-    """
-
-    :param endpoint:
-    :param request:
-    :param sid:
-    :return:
-    """
-    # create the response
-    aresp = AuthorizationResponse()
-    if request.get("state"):
-        aresp["state"] = request["state"]
-
-    if "response_type" in request and request["response_type"] == ["none"]:
-        fragment_enc = False
-    else:
-        _context = endpoint.endpoint_context
-        _sinfo = _context.sdb[sid]
-
-        if request.get("scope"):
-            aresp["scope"] = request["scope"]
-
-        rtype = set(request["response_type"][:])
-        handled_response_type = []
-
-        fragment_enc = True
-        if len(rtype) == 1 and "code" in rtype:
-            fragment_enc = False
-
-        if "code" in request["response_type"]:
-            _code = aresp["code"] = _context.sdb[sid]["code"]
-            handled_response_type.append("code")
-        else:
-            _context.sdb.update(sid, code=None)
-            _code = None
-
-        if "token" in rtype:
-            _dic = _context.sdb.upgrade_to_token(issue_refresh=False, key=sid)
-
-            logger.debug("_dic: %s" % sanitize(_dic))
-            for key, val in _dic.items():
-                if key in aresp.parameters() and val is not None:
-                    aresp[key] = val
-
-            handled_response_type.append("token")
-
-        _access_token = aresp.get("access_token", None)
-
-        if "id_token" in request["response_type"]:
-            kwargs = {}
-            if {"code", "id_token", "token"}.issubset(rtype):
-                kwargs = {"code": _code, "access_token": _access_token}
-            elif {"code", "id_token"}.issubset(rtype):
-                kwargs = {"code": _code}
-            elif {"id_token", "token"}.issubset(rtype):
-                kwargs = {"access_token": _access_token}
-
-            if request["response_type"] == ["id_token"]:
-                kwargs["user_claims"] = True
-
-            try:
-                id_token = _context.idtoken.make(request, _sinfo, **kwargs)
-            except (JWEException, NoSuitableSigningKeys) as err:
-                logger.warning(str(err))
-                resp = AuthorizationErrorResponse(
-                    error="invalid_request",
-                    error_description="Could not sign/encrypt id_token",
-                )
-                return {"response_args": resp, "fragment_enc": fragment_enc}
-
-            aresp["id_token"] = id_token
-            _sinfo["id_token"] = id_token
-            handled_response_type.append("id_token")
-
-        not_handled = rtype.difference(handled_response_type)
-        if not_handled:
-            resp = AuthorizationErrorResponse(
-                error="invalid_request", error_description="unsupported_response_type"
-            )
-            return {"response_args": resp, "fragment_enc": fragment_enc}
-
-    return {"response_args": aresp, "fragment_enc": fragment_enc}
 
 
 def proposed_user(request):
@@ -180,6 +93,7 @@ def re_authenticate(request, authn):
 class Authorization(Endpoint):
     request_cls = oidc.AuthorizationRequest
     response_cls = oidc.AuthorizationResponse
+    error_cls = oidc.AuthorizationErrorResponse
     request_format = "urlencoded"
     response_format = "urlencoded"
     response_placement = "url"
@@ -261,7 +175,7 @@ class Authorization(Endpoint):
             )
             if _resp.status_code == 200:
                 args = {"keyjar": endpoint_context.keyjar, "issuer": client_id}
-                _ver_request = AuthorizationRequest().from_jwt(_resp.text, **args)
+                _ver_request = self.request_cls().from_jwt(_resp.text, **args)
                 self.allowed_request_algorithms(
                     client_id,
                     endpoint_context,
@@ -303,7 +217,7 @@ class Authorization(Endpoint):
         """
         if not request:
             logger.debug("No AuthzRequest")
-            return AuthorizationErrorResponse(
+            return self.error_cls(
                 error="invalid_request", error_description="Can not parse AuthzRequest"
             )
 
@@ -314,13 +228,13 @@ class Authorization(Endpoint):
             logger.error(
                 "Client ID ({}) not in client database".format(request["client_id"])
             )
-            return AuthorizationErrorResponse(
+            return self.error_cls(
                 error="unauthorized_client", error_description="unknown client"
             )
 
         # Is the asked for response_type among those that are permitted
         if not self.verify_response_type(request, _cinfo):
-            return AuthorizationErrorResponse(
+            return self.error_cls(
                 error="invalid_request",
                 error_description="Trying to use unregistered response_type",
             )
@@ -329,7 +243,7 @@ class Authorization(Endpoint):
         try:
             redirect_uri = get_uri(endpoint_context, request, "redirect_uri")
         except (RedirectURIError, ParameterError, UnknownClient) as err:
-            return AuthorizationErrorResponse(
+            return self.error_cls(
                 error="invalid_request",
                 error_description="{}:{}".format(err.__class__.__name__, err),
             )
@@ -469,6 +383,89 @@ class Authorization(Endpoint):
 
         return {"authn_event": authn_event, "identity": identity, "user": user}
 
+    def create_authn_response(self, request, sid):
+        """
+
+        :param self:
+        :param request:
+        :param sid:
+        :return:
+        """
+        # create the response
+        aresp = self.response_cls()
+        if request.get("state"):
+            aresp["state"] = request["state"]
+
+        if "response_type" in request and request["response_type"] == ["none"]:
+            fragment_enc = False
+        else:
+            _context = self.endpoint_context
+            _sinfo = _context.sdb[sid]
+
+            if request.get("scope"):
+                aresp["scope"] = request["scope"]
+
+            rtype = set(request["response_type"][:])
+            handled_response_type = []
+
+            fragment_enc = True
+            if len(rtype) == 1 and "code" in rtype:
+                fragment_enc = False
+
+            if "code" in request["response_type"]:
+                _code = aresp["code"] = _context.sdb[sid]["code"]
+                handled_response_type.append("code")
+            else:
+                _context.sdb.update(sid, code=None)
+                _code = None
+
+            if "token" in rtype:
+                _dic = _context.sdb.upgrade_to_token(issue_refresh=False, key=sid)
+
+                logger.debug("_dic: %s" % sanitize(_dic))
+                for key, val in _dic.items():
+                    if key in aresp.parameters() and val is not None:
+                        aresp[key] = val
+
+                handled_response_type.append("token")
+
+            _access_token = aresp.get("access_token", None)
+
+            if "id_token" in request["response_type"]:
+                kwargs = {}
+                if {"code", "id_token", "token"}.issubset(rtype):
+                    kwargs = {"code": _code, "access_token": _access_token}
+                elif {"code", "id_token"}.issubset(rtype):
+                    kwargs = {"code": _code}
+                elif {"id_token", "token"}.issubset(rtype):
+                    kwargs = {"access_token": _access_token}
+
+                if request["response_type"] == ["id_token"]:
+                    kwargs["user_claims"] = True
+
+                try:
+                    id_token = _context.idtoken.make(request, _sinfo, **kwargs)
+                except (JWEException, NoSuitableSigningKeys) as err:
+                    logger.warning(str(err))
+                    resp = self.error_cls(
+                        error="invalid_request",
+                        error_description="Could not sign/encrypt id_token",
+                    )
+                    return {"response_args": resp, "fragment_enc": fragment_enc}
+
+                aresp["id_token"] = id_token
+                _sinfo["id_token"] = id_token
+                handled_response_type.append("id_token")
+
+            not_handled = rtype.difference(handled_response_type)
+            if not_handled:
+                resp = self.error_cls(
+                    error="invalid_request", error_description="unsupported_response_type"
+                )
+                return {"response_args": resp, "fragment_enc": fragment_enc}
+
+        return {"response_args": aresp, "fragment_enc": fragment_enc}
+
     def aresp_check(self, aresp, request):
         return ""
 
@@ -503,7 +500,7 @@ class Authorization(Endpoint):
         return kwargs
 
     def error_response(self, response_info, error, error_description):
-        resp = AuthorizationErrorResponse(
+        resp = self.error_cls(
             error=error, error_description=str(error_description)
         )
         response_info["response_args"] = resp
@@ -552,7 +549,7 @@ class Authorization(Endpoint):
                 response_info, "access_denied", "Session is revoked"
             )
 
-        response_info = create_authn_response(self, request, sid)
+        response_info = self.create_authn_response(request, sid)
 
         logger.debug("Known clients: {}".format(list(self.endpoint_context.cdb.keys())))
 
@@ -676,7 +673,7 @@ class Authorization(Endpoint):
         :return: dictionary
         """
 
-        if isinstance(request_info, AuthorizationErrorResponse):
+        if isinstance(request_info, self.error_cls):
             return request_info
 
         _cid = request_info["client_id"]

--- a/src/oidcendpoint/oidc/registration.py
+++ b/src/oidcendpoint/oidc/registration.py
@@ -163,7 +163,7 @@ class Registration(Endpoint):
             plruri = []
             for uri in request["post_logout_redirect_uris"]:
                 if urlparse(uri).fragment:
-                    err = ClientRegistrationErrorResponse(
+                    err = self.error_cls(
                         error="invalid_configuration_parameter",
                         error_description="post_logout_redirect_uris contains fragment",
                     )
@@ -176,7 +176,7 @@ class Registration(Endpoint):
                 ruri = self.verify_redirect_uris(request)
                 _cinfo["redirect_uris"] = ruri
             except InvalidRedirectURIError as e:
-                return ClientRegistrationErrorResponse(
+                return self.error_cls(
                     error="invalid_redirect_uri", error_description=str(e)
                 )
 
@@ -185,7 +185,7 @@ class Registration(Endpoint):
             for uri in request["request_uris"]:
                 _up = urlparse(uri)
                 if _up.query:
-                    err = ClientRegistrationErrorResponse(
+                    err = self.error_cls(
                         error="invalid_configuration_parameter",
                         error_description="request_uris contains query part",
                     )
@@ -427,11 +427,11 @@ class Registration(Endpoint):
             return _cinfo
 
         args = dict(
-            [(k, v) for k, v in _cinfo.items() if k in RegistrationResponse.c_param]
+            [(k, v) for k, v in _cinfo.items() if k in self.response_cls.c_param]
         )
 
         comb_uri(args)
-        response = RegistrationResponse(**args)
+        response = self.response_cls(**args)
 
         # Add the client_secret as a symmetric key to the key jar
         if client_secret:

--- a/src/oidcendpoint/oidc/token.py
+++ b/src/oidcendpoint/oidc/token.py
@@ -105,7 +105,7 @@ class AccessToken(Endpoint):
                 _idtoken = _context.idtoken.make(req, _info, _authn_req)
             except (JWEException, NoSuitableSigningKeys) as err:
                 logger.warning(str(err))
-                resp = TokenErrorResponse(
+                resp = self.error_cls(
                     error="invalid_request",
                     error_description="Could not sign/encrypt id_token",
                 )

--- a/src/oidcendpoint/oidc/token_coop.py
+++ b/src/oidcendpoint/oidc/token_coop.py
@@ -119,7 +119,7 @@ class TokenCoop(Endpoint):
                 _idtoken = _context.idtoken.make(req, _info, _authn_req)
             except (JWEException, NoSuitableSigningKeys) as err:
                 logger.warning(str(err))
-                resp = TokenErrorResponse(
+                resp = self.error_cls(
                     error="invalid_request",
                     error_description="Could not sign/encrypt id_token",
                 )

--- a/tests/test_24_oauth2_authorization_endpoint.py
+++ b/tests/test_24_oauth2_authorization_endpoint.py
@@ -19,7 +19,6 @@ from oidcmsg.oauth2 import AuthorizationResponse
 from oidcmsg.time_util import in_a_while
 
 from oidcendpoint.common.authorization import FORM_POST
-from oidcendpoint.common.authorization import create_authn_response
 from oidcendpoint.common.authorization import get_uri
 from oidcendpoint.common.authorization import inputs
 from oidcendpoint.common.authorization import join_query
@@ -410,7 +409,7 @@ class TestEndpoint(object):
             "id_token_signed_response_alg": "ES256",
         }
 
-        resp = create_authn_response(self.endpoint, request, "session_id")
+        resp = self.endpoint.create_authn_response(request, "session_id")
         assert isinstance(resp["response_args"], AuthorizationErrorResponse)
 
     def test_setup_auth(self):

--- a/tests/test_24_oauth2_authorization_endpoint.py
+++ b/tests/test_24_oauth2_authorization_endpoint.py
@@ -245,14 +245,9 @@ class TestEndpoint(object):
         _orig_req = AUTH_REQ_DICT.copy()
         _orig_req["response_type"] = "code token"
         msg = ''
-        try:
-            _pr_resp = self.endpoint.parse_request(_orig_req)
-        except UnAuthorizedClient as e:
-            msg = e.args[0]
-            assert isinstance(msg, dict)
-            assert msg["error"] == "invalid_request"
-        else:
-            raise Exception('Should be UnAuthorized: {}'.format(msg))
+        _pr_resp = self.endpoint.parse_request(_orig_req)
+        assert isinstance(_pr_resp, AuthorizationErrorResponse)
+        assert _pr_resp["error"] == "invalid_request"
 
     def test_verify_uri_unknown_client(self):
         request = {"redirect_uri": "https://rp.example.com/cb"}

--- a/tests/test_24_oidc_authorization_endpoint.py
+++ b/tests/test_24_oidc_authorization_endpoint.py
@@ -315,26 +315,16 @@ class TestEndpoint(object):
         _orig_req = AUTH_REQ_DICT.copy()
         _orig_req["response_type"] = "id_token token"
         _orig_req["nonce"] = "rnd_nonce"
-        try:
-            _pr_resp = self.endpoint.parse_request(_orig_req)
-        except UnAuthorizedClient as e:
-            msg = e.args[0]
-            assert isinstance(msg, dict)
-            assert msg["error"] == "invalid_request"
-        else:
-            raise Exception('Should be UnAuthorized: {}'.format(msg))
+        _pr_resp = self.endpoint.parse_request(_orig_req)
+        assert isinstance(_pr_resp, AuthorizationErrorResponse)
+        assert _pr_resp["error"] == "invalid_request"
 
     def test_do_response_code_token(self):
         _orig_req = AUTH_REQ_DICT.copy()
         _orig_req["response_type"] = "code token"
-        try:
-            _pr_resp = self.endpoint.parse_request(_orig_req)
-        except UnAuthorizedClient as e:
-            msg = e.args[0]
-            assert isinstance(msg, dict)
-            assert msg["error"] == "invalid_request"
-        else:
-            raise Exception('Should be UnAuthorized: {}'.format(msg))
+        _pr_resp = self.endpoint.parse_request(_orig_req)
+        assert isinstance(_pr_resp, AuthorizationErrorResponse)
+        assert _pr_resp["error"] == "invalid_request"
 
     def test_do_response_code_id_token(self):
         _orig_req = AUTH_REQ_DICT.copy()

--- a/tests/test_24_oidc_authorization_endpoint.py
+++ b/tests/test_24_oidc_authorization_endpoint.py
@@ -39,7 +39,6 @@ from oidcendpoint.login_hint import LoginHint2Acrs
 from oidcendpoint.oidc import userinfo
 from oidcendpoint.oidc.authorization import Authorization
 from oidcendpoint.oidc.authorization import acr_claims
-from oidcendpoint.oidc.authorization import create_authn_response
 from oidcendpoint.oidc.authorization import get_uri
 from oidcendpoint.oidc.authorization import inputs
 from oidcendpoint.oidc.authorization import re_authenticate
@@ -558,7 +557,7 @@ class TestEndpoint(object):
             "id_token_signed_response_alg": "ES256",
         }
 
-        resp = create_authn_response(self.endpoint, request, "session_id")
+        resp = self.endpoint.create_authn_response(request, "session_id")
         assert isinstance(resp["response_args"], AuthorizationErrorResponse)
 
     def test_setup_auth(self):

--- a/tests/test_33_pkce.py
+++ b/tests/test_33_pkce.py
@@ -273,11 +273,10 @@ class TestEndpoint(object):
         _authn_req = AUTH_REQ.copy()
 
         _pr_resp = self.authn_endpoint.parse_request(_authn_req.to_dict())
-        resp = self.authn_endpoint.process_request(_pr_resp)
 
-        assert isinstance(resp, AuthorizationErrorResponse)
-        assert resp["error"] == "invalid_request"
-        assert resp["error_description"] == "Missing required code_challenge"
+        assert isinstance(_pr_resp, AuthorizationErrorResponse)
+        assert _pr_resp["error"] == "invalid_request"
+        assert _pr_resp["error_description"] == "Missing required code_challenge"
 
     def test_not_essential(self, conf):
         conf["add_on"]["pkce"]["kwargs"]["essential"] = False
@@ -303,11 +302,10 @@ class TestEndpoint(object):
         _authn_req["code_challenge_method"] = "doupa"
 
         _pr_resp = self.authn_endpoint.parse_request(_authn_req.to_dict())
-        resp = self.authn_endpoint.process_request(_pr_resp)
 
-        assert isinstance(resp, AuthorizationErrorResponse)
-        assert resp["error"] == "invalid_request"
-        assert resp[
+        assert isinstance(_pr_resp, AuthorizationErrorResponse)
+        assert _pr_resp["error"] == "invalid_request"
+        assert _pr_resp[
             "error_description"
         ] == "Unsupported code_challenge_method={}".format(
             _authn_req["code_challenge_method"]
@@ -324,11 +322,10 @@ class TestEndpoint(object):
         _authn_req["code_challenge_method"] = _cc_info["code_challenge_method"]
 
         _pr_resp = authn_endpoint.parse_request(_authn_req.to_dict())
-        resp = authn_endpoint.process_request(_pr_resp)
 
-        assert isinstance(resp, AuthorizationErrorResponse)
-        assert resp["error"] == "invalid_request"
-        assert resp[
+        assert isinstance(_pr_resp, AuthorizationErrorResponse)
+        assert _pr_resp["error"] == "invalid_request"
+        assert _pr_resp[
             "error_description"
         ] == "Unsupported code_challenge_method={}".format(
             _authn_req["code_challenge_method"]

--- a/tests/test_33_pkce.py
+++ b/tests/test_33_pkce.py
@@ -6,9 +6,11 @@ from secrets import choice
 
 import pytest
 import yaml
-from cryptojwt.utils import b64e
+from oidcmsg.oauth2 import AuthorizationErrorResponse
 from oidcmsg.oidc import AccessTokenRequest
 from oidcmsg.oidc import AuthorizationRequest
+from oidcmsg.oidc import AuthorizationResponse
+from oidcmsg.oidc import TokenErrorResponse
 
 from oidcendpoint.cookie import CookieDealer
 from oidcendpoint.endpoint_context import EndpointContext
@@ -78,11 +80,11 @@ client_yaml = """
 oidc_clients:
   client_1:
     "client_secret": 'hemligt'
-    "redirect_uris": 
+    "redirect_uris":
         - ['https://example.com/cb', '']
     "client_salt": "salted"
     'token_endpoint_auth_method': 'client_secret_post'
-    'response_types': 
+    'response_types':
         - 'code'
         - 'token'
         - 'code id_token'
@@ -106,6 +108,74 @@ oidc_clients:
 """
 
 
+@pytest.fixture
+def conf():
+    return {
+        "issuer": "https://example.com/",
+        "password": "mycket hemligt zebra",
+        "token_expires_in": 600,
+        "grant_expires_in": 300,
+        "refresh_token_expires_in": 86400,
+        "verify_ssl": False,
+        "capabilities": CAPABILITIES,
+        "keys": {"uri_path": "static/jwks.json", "key_defs": KEYDEFS},
+        "id_token": {
+            "class": IDToken,
+            "kwargs": {
+                "available_claims": {
+                    "email": {"essential": True},
+                    "email_verified": {"essential": True},
+                }
+            },
+        },
+        "endpoint": {
+            "authorization": {
+                "path": "{}/authorization",
+                "class": Authorization,
+                "kwargs": {},
+            },
+            "token": {
+                "path": "{}/token",
+                "class": AccessToken,
+                "kwargs": {
+                    "client_authn_method": [
+                        "client_secret_post",
+                        "client_secret_basic",
+                        "client_secret_jwt",
+                        "private_key_jwt",
+                    ]
+                },
+            },
+        },
+        "authentication": {
+            "anon": {
+                "acr": "http://www.swamid.se/policy/assurance/al1",
+                "class": "oidcendpoint.user_authn.user.NoAuthn",
+                "kwargs": {"user": "diana"},
+            }
+        },
+        "template_dir": "template",
+        "add_on": {
+            "pkce": {
+                "function": "oidcendpoint.oidc.add_on.pkce.add_pkce_support",
+                "kwargs": {"essential": True},
+            }
+        },
+        "cookie_dealer": {
+            "class": CookieDealer,
+            "kwargs": {
+                "sign_key": "ghsNKDDLshZTPn974nOsIGhedULrsqnsGoBFBLwUKuJhE2ch",
+                "default_values": {
+                    "name": "oidcop",
+                    "domain": "127.0.0.1",
+                    "path": "/",
+                    "max_age": 3600,
+                },
+            },
+        },
+    }
+
+
 def unreserved(size=64):
     return "".join(choice(BASECH) for _ in range(size))
 
@@ -116,16 +186,13 @@ def _code_challenge():
     """
     # code_verifier: string of length cv_len
     code_verifier = unreserved(64)
-    _cv = code_verifier.encode()
 
     _method = "S256"
 
     # Pick hash method
     _hash_method = CC_METHOD[_method]
-    # Use it on the code_verifier
-    _hv = _hash_method(_cv).digest()
     # base64 encode the hash value
-    code_challenge = b64e(_hv).decode("ascii")
+    code_challenge = _hash_method(code_verifier)
 
     return {
         "code_challenge": code_challenge,
@@ -134,81 +201,30 @@ def _code_challenge():
     }
 
 
+def create_endpoint(config):
+    endpoint_context = EndpointContext(config)
+    _clients = yaml.safe_load(io.StringIO(client_yaml))
+    endpoint_context.cdb = _clients["oidc_clients"]
+    endpoint_context.keyjar.import_jwks(
+        endpoint_context.keyjar.export_jwks(True, ""), config["issuer"]
+    )
+    return endpoint_context
+
+
 class TestEndpoint(object):
     @pytest.fixture(autouse=True)
-    def create_endpoint(self):
-        conf = {
-            "issuer": "https://example.com/",
-            "password": "mycket hemligt zebra",
-            "token_expires_in": 600,
-            "grant_expires_in": 300,
-            "refresh_token_expires_in": 86400,
-            "verify_ssl": False,
-            "capabilities": CAPABILITIES,
-            "keys": {"uri_path": "static/jwks.json", "key_defs": KEYDEFS},
-            "id_token": {
-                "class": IDToken,
-                "kwargs": {
-                    "available_claims": {
-                        "email": {"essential": True},
-                        "email_verified": {"essential": True},
-                    }
-                },
-            },
-            "endpoint": {
-                "authorization": {
-                    "path": "{}/authorization",
-                    "class": Authorization,
-                    "kwargs": {},
-                },
-                "token": {
-                    "path": "{}/token",
-                    "class": AccessToken,
-                    "kwargs": {
-                        "client_authn_method": [
-                            "client_secret_post",
-                            "client_secret_basic",
-                            "client_secret_jwt",
-                            "private_key_jwt",
-                        ]
-                    },
-                },
-            },
-            "authentication": {
-                "anon": {
-                    "acr": "http://www.swamid.se/policy/assurance/al1",
-                    "class": "oidcendpoint.user_authn.user.NoAuthn",
-                    "kwargs": {"user": "diana"},
-                }
-            },
-            "template_dir": "template",
-            "add_on": {
-                "pkce": {
-                    "function": "oidcendpoint.oidc.add_on.pkce.add_pkce_support",
-                    "kwargs": {"essential": True},
-                }
-            },
-            "cookie_dealer": {
-                "class": CookieDealer,
-                "kwargs": {
-                    "sign_key": "ghsNKDDLshZTPn974nOsIGhedULrsqnsGoBFBLwUKuJhE2ch",
-                    "default_values": {
-                        "name": "oidcop",
-                        "domain": "127.0.0.1",
-                        "path": "/",
-                        "max_age": 3600,
-                    },
-                },
-            },
-        }
-        endpoint_context = EndpointContext(conf)
-        _clients = yaml.safe_load(io.StringIO(client_yaml))
-        endpoint_context.cdb = _clients["oidc_clients"]
-        endpoint_context.keyjar.import_jwks(
-            endpoint_context.keyjar.export_jwks(True, ""), conf["issuer"]
-        )
+    def create_endpoint(self, conf):
+        endpoint_context = create_endpoint(conf)
         self.authn_endpoint = endpoint_context.endpoint["authorization"]
         self.token_endpoint = endpoint_context.endpoint["token"]
+
+    def test_unsupported_code_challenge_methods(self, conf):
+        conf["add_on"]["pkce"]["kwargs"]["code_challenge_methods"] = ["dada"]
+
+        with pytest.raises(ValueError) as exc:
+            create_endpoint(conf)
+
+        assert exc.value.args[0] == "Unsupported method: dada"
 
     def test_parse(self):
         _cc_info = _code_challenge()
@@ -217,15 +233,144 @@ class TestEndpoint(object):
         _authn_req["code_challenge_method"] = _cc_info["code_challenge_method"]
 
         _pr_resp = self.authn_endpoint.parse_request(_authn_req.to_dict())
-        _resp = self.authn_endpoint.process_request(_pr_resp)
+        resp = self.authn_endpoint.process_request(_pr_resp)
+
+        assert isinstance(resp["response_args"], AuthorizationResponse)
 
         _token_request = TOKEN_REQ.copy()
-        sids = self.token_endpoint.endpoint_context.sdb.get_sid_by_kv(
-            _authn_req["state"], "state"
-        )
-        _token_request["code"] = self.token_endpoint.endpoint_context.sdb[sids[0]][
-            "code"
+        session = self.token_endpoint.endpoint_context.sdb[
+            resp["response_args"]["code"]
         ]
+        _token_request["code"] = session["code"]
         _token_request["code_verifier"] = _cc_info["code_verifier"]
         _req = self.token_endpoint.parse_request(_token_request)
-        assert _req
+
+        assert isinstance(_req, AccessTokenRequest)
+
+    def test_no_code_challenge_method(self):
+        _cc_info = _code_challenge()
+        _authn_req = AUTH_REQ.copy()
+        _authn_req["code_challenge"] = _cc_info["code_challenge"]
+
+        _pr_resp = self.authn_endpoint.parse_request(_authn_req.to_dict())
+        resp = self.authn_endpoint.process_request(_pr_resp)
+
+        assert isinstance(resp["response_args"], AuthorizationResponse)
+
+        session = self.token_endpoint.endpoint_context.sdb[
+            resp["response_args"]["code"]
+        ]
+        session["authn_req"]["code_challenge_method"] == "plain"
+
+        _token_request = TOKEN_REQ.copy()
+        _token_request["code"] = session["code"]
+        _token_request["code_verifier"] = _cc_info["code_challenge"]
+        _req = self.token_endpoint.parse_request(_token_request)
+
+        assert isinstance(_req, AccessTokenRequest)
+
+    def test_no_code_challenge(self):
+        _authn_req = AUTH_REQ.copy()
+
+        _pr_resp = self.authn_endpoint.parse_request(_authn_req.to_dict())
+        resp = self.authn_endpoint.process_request(_pr_resp)
+
+        assert isinstance(resp, AuthorizationErrorResponse)
+        assert resp["error"] == "invalid_request"
+        assert resp["error_description"] == "Missing required code_challenge"
+
+    def test_not_essential(self, conf):
+        conf["add_on"]["pkce"]["kwargs"]["essential"] = False
+        endpoint_context = create_endpoint(conf)
+        authn_endpoint = endpoint_context.endpoint["authorization"]
+        token_endpoint = endpoint_context.endpoint["token"]
+        _authn_req = AUTH_REQ.copy()
+
+        _pr_resp = authn_endpoint.parse_request(_authn_req.to_dict())
+        resp = authn_endpoint.process_request(_pr_resp)
+
+        assert isinstance(resp["response_args"], AuthorizationResponse)
+
+        _token_request = TOKEN_REQ.copy()
+        _token_request["code"] = resp["response_args"]["code"]
+        _req = token_endpoint.parse_request(_token_request)
+
+        assert isinstance(_req, AccessTokenRequest)
+
+    def test_unknown_code_challenge_method(self):
+        _authn_req = AUTH_REQ.copy()
+        _authn_req["code_challenge"] = "aba"
+        _authn_req["code_challenge_method"] = "doupa"
+
+        _pr_resp = self.authn_endpoint.parse_request(_authn_req.to_dict())
+        resp = self.authn_endpoint.process_request(_pr_resp)
+
+        assert isinstance(resp, AuthorizationErrorResponse)
+        assert resp["error"] == "invalid_request"
+        assert resp[
+            "error_description"
+        ] == "Unsupported code_challenge_method={}".format(
+            _authn_req["code_challenge_method"]
+        )
+
+    def test_unsupported_code_challenge_method(self, conf):
+        conf["add_on"]["pkce"]["kwargs"]["code_challenge_methods"] = ["plain"]
+        endpoint_context = create_endpoint(conf)
+        authn_endpoint = endpoint_context.endpoint["authorization"]
+
+        _cc_info = _code_challenge()
+        _authn_req = AUTH_REQ.copy()
+        _authn_req["code_challenge"] = _cc_info["code_challenge"]
+        _authn_req["code_challenge_method"] = _cc_info["code_challenge_method"]
+
+        _pr_resp = authn_endpoint.parse_request(_authn_req.to_dict())
+        resp = authn_endpoint.process_request(_pr_resp)
+
+        assert isinstance(resp, AuthorizationErrorResponse)
+        assert resp["error"] == "invalid_request"
+        assert resp[
+            "error_description"
+        ] == "Unsupported code_challenge_method={}".format(
+            _authn_req["code_challenge_method"]
+        )
+
+    def test_wrong_code_verifier(self):
+        _cc_info = _code_challenge()
+        _authn_req = AUTH_REQ.copy()
+        _authn_req["code_challenge"] = _cc_info["code_challenge"]
+        _authn_req["code_challenge_method"] = _cc_info["code_challenge_method"]
+
+        _pr_resp = self.authn_endpoint.parse_request(_authn_req.to_dict())
+        resp = self.authn_endpoint.process_request(_pr_resp)
+
+        _token_request = TOKEN_REQ.copy()
+        session = self.token_endpoint.endpoint_context.sdb[
+            resp["response_args"]["code"]
+        ]
+        _token_request["code"] = session["code"]
+        _token_request["code_verifier"] = "aba"
+        resp = self.token_endpoint.parse_request(_token_request)
+
+        assert isinstance(resp, TokenErrorResponse)
+        assert resp["error"] == "invalid_grant"
+        assert resp["error_description"] == "PKCE check failed"
+
+    def test_no_code_verifier(self):
+        _cc_info = _code_challenge()
+        _authn_req = AUTH_REQ.copy()
+        _authn_req["code_challenge"] = _cc_info["code_challenge"]
+        _authn_req["code_challenge_method"] = _cc_info["code_challenge_method"]
+
+        _pr_resp = self.authn_endpoint.parse_request(_authn_req.to_dict())
+        resp = self.authn_endpoint.process_request(_pr_resp)
+
+        _token_request = TOKEN_REQ.copy()
+        session = self.token_endpoint.endpoint_context.sdb[
+            resp["response_args"]["code"]
+        ]
+        _token_request["code"] = session["code"]
+        resp = self.token_endpoint.parse_request(_token_request)
+
+        assert isinstance(resp, TokenErrorResponse)
+        assert resp["error"] == "invalid_grant"
+        assert resp["error_description"] == "Missing code_verifier"


### PR DESCRIPTION
The `do_post_parse_request` mechanism calls a sequence of hooks without taking into account their result. This results in the problem that if a hook returns an error the rest of the hooks are called nonetheless (this may be desirable in some cases?). 

Currently there are 2 different error handling approaches implemented:
- Return an error response class instance, this is done in `_post_parse_request`.
- Throw an exception this is done in pkce and `_do_request_uri`.

The second choice has the drawback that the response args are hidden in the exception. The first approach seems clearer. In this PR the first approach is implemented.

Another problem is whether we should call the rest of the hooks if one of them returns an error response. If we agree that there is no use case to have the post parse hooks to handle the errors detected in a previous step, then we should stop parsing when an error is returned. The other choice (which is implemented in this PR) is to leave the handling of errors up to the hooks.