### PR TITLE
[Client secret expired] A more eloquent log message

### DIFF
--- a/src/oidcendpoint/client_authn.py
+++ b/src/oidcendpoint/client_authn.py
@@ -395,7 +395,8 @@ def verify_client(
                 raise UnknownClient("Unknown Client ID")
 
         if not valid_client_info(_cinfo):
-            logger.warning("Client registration has timed out")
+            logger.warning("Client registration has timed out or "
+                           "client secret is expired.")
             raise InvalidClient("Not valid client")
 
         # store what authn method was used


### PR DESCRIPTION
Minor change to get a better information to log messages.
I found a client with a expired secret and in the log I simply gave this information.