### PR TITLE
[Userinfo endpoint] Exception if token was released with unspecified/unknow scope

### DIFF
--- a/src/oidcendpoint/userinfo.py
+++ b/src/oidcendpoint/userinfo.py
@@ -3,7 +3,7 @@ import logging
 from oidcmsg.oidc import Claims
 
 from oidcendpoint import sanitize
-from oidcendpoint.exception import FailedAuthentication
+from oidcendpoint.exception import ImproperlyConfigured
 from oidcendpoint.scopes import convert_scopes2claims
 
 logger = logging.getLogger(__name__)
@@ -157,6 +157,9 @@ def collect_user_info(
             logger.debug("userinfo_claim: %s" % sanitize(userinfo_claims.to_dict()))
         else:
             userinfo_claims = None
+            logger.warning(("Client {} doesn't have any claims "
+                            "belonging to one or more scopes.").format(authn_req["client_id"]))
+            raise ImproperlyConfigured("Some additional scopes doesn't have any claims.")
 
     logger.debug("Session info: %s" % sanitize(session))
 


### PR DESCRIPTION
Error
------
````
ERROR:oidc_op.views:argument of type 'NoneType' is not iterable
Traceback (most recent call last):
  File "/home/wert/DEV3/OIDC-Project/django-oidc-op/example/oidc_op/views.py", line 175, in service_endpoint
    args = endpoint.process_request(req_args, **kwargs)
  File "/home/wert/DEV3/OIDC-Project/env/lib/python3.7/site-packages/oidcendpoint/oidc/userinfo.py", line 124, in process_request
    info = collect_user_info(self.endpoint_context, session)
  File "/home/wert/DEV3/OIDC-Project/env/lib/python3.7/site-packages/oidcendpoint/userinfo.py", line 173, in collect_user_info
    if "sub" in userinfo_claims:
TypeError: argument of type 'NoneType' is not iterable
[2020-09-02 13:32:25,006] Internal Server Error: /userinfo [(ERROR) django.request.log_response:228]
ERROR:django.request:Internal Server Error: /userinfo
````

How to reproduce
------------------------

Configure a RP in OP with some custom/unknow scope in allowed_scopes.

Result after this PR
--------------------------
A specific Exception will be raised with a eloquent error message.

````
[2020-09-02 14:19:59,043] authn_info: {'token': 'eyJhbGciOiJFUzI1NiIsImtpZCI6IlQwZGZTM1ZVYUcxS1ZubG9VVTQwUXpJMlMyMHpjSHBRYlMxdGIzZ3hZVWhCYzNGaFZWTlpTbWhMTUEifQ.eyJzaWQiOiAiYzk4MDQ2MmUwMjU0YzI2MDY4YjI4NGI3ZGM5YWIxMTk3NzdlM2JjZWI0NDM1ZWRiZDdjYjA4YTQiLCAidHR5cGUiOiAiVCIsICJzdWIiOiAiMDc2ZWNjYTk0ZmU0NTQ2N2I0NDM1ZDhlZWFkMjE4OGFkMzc3MWUxMGZmNjcyY2UxOTMwYzA0YWE4NjI0MTgxYyIsICJpc3MiOiAiaHR0cHM6Ly8xMjcuMC4wLjE6ODAwMCIsICJpYXQiOiAxNTk5MDU2Mzk4LCAiZXhwIjogMTU5OTA1OTk5OCwgImF1ZCI6IFsiMVVVbDZjd05pZ21qIiwgImh0dHBzOi8vMTI3LjAuMC4xOjgwMDAiXX0.Mlq3p7mmefGF_IR5XETdnn51HzDzX-Ln6vJLgYfUBMcX98ckB8UPQX4xY90dKRRkxjtksdQlCloLQc93ZB9fNQ', 'method': 'bearer_header', 'client_id': '1UUl6cwNigmj'} [(DEBUG) oidcendpoint.endpoint.client_authentication:299]
[2020-09-02 14:19:59,172] Client 1UUl6cwNigmj doesn't have any claims belonging to one or more scopes. [(WARNING) oidcendpoint.userinfo.collect_user_info:161]
[2020-09-02 14:19:59,172] Some additional scopes doesn't have any claims. [(ERROR) oidc_op.views.service_endpoint:181]
Traceback (most recent call last):
  File "/home/wert/DEV3/OIDC-Project/django-oidc-op/example/oidc_op/views.py", line 175, in service_endpoint
    args = endpoint.process_request(req_args, **kwargs)
  File "/home/wert/DEV3/OIDC-Project/env/lib/python3.7/site-packages/oidcendpoint/oidc/userinfo.py", line 124, in process_request
    info = collect_user_info(self.endpoint_context, session)
  File "/home/wert/DEV3/OIDC-Project/env/lib/python3.7/site-packages/oidcendpoint/userinfo.py", line 162, in collect_user_info
    raise ImproperlyConfigured("Some additional scopes doesn't have any claims.")
oidcendpoint.exception.ImproperlyConfigured: Some additional scopes doesn't have any claims.
ERROR:oidc_op.views:Some additional scopes doesn't have any claims.
Traceback (most recent call last):
  File "/home/wert/DEV3/OIDC-Project/django-oidc-op/example/oidc_op/views.py", line 175, in service_endpoint
    args = endpoint.process_request(req_args, **kwargs)
  File "/home/wert/DEV3/OIDC-Project/env/lib/python3.7/site-packages/oidcendpoint/oidc/userinfo.py", line 124, in process_request
    info = collect_user_info(self.endpoint_context, session)
  File "/home/wert/DEV3/OIDC-Project/env/lib/python3.7/site-packages/oidcendpoint/userinfo.py", line 162, in collect_user_info
    raise ImproperlyConfigured("Some additional scopes doesn't have any claims.")
oidcendpoint.exception.ImproperlyConfigured: Some additional scopes doesn't have any claims.
[2020-09-02 14:19:59,173] Internal Server Error: /userinfo [(ERROR) django.request.log_response:228]
ERROR:django.request:Internal Server Error: /userinfo
```` 