### PR TITLE
[Option] Authorization denied for unallowed scopes

### DIFF
--- a/src/oidcendpoint/exception.py
+++ b/src/oidcendpoint/exception.py
@@ -66,6 +66,10 @@ class UnAuthorizedClient(OidcEndpointError):
     pass
 
 
+class UnAuthorizedClientScope(OidcEndpointError):
+    pass
+
+
 class InvalidCookieSign(Exception):
     pass
 

--- a/src/oidcendpoint/oauth2/authorization.py
+++ b/src/oidcendpoint/oauth2/authorization.py
@@ -33,6 +33,7 @@ from oidcendpoint.exception import RedirectURIError
 from oidcendpoint.exception import ServiceError
 from oidcendpoint.exception import TamperAllert
 from oidcendpoint.exception import ToOld
+from oidcendpoint.exception import UnAuthorizedClientScope
 from oidcendpoint.exception import UnknownClient
 from oidcendpoint.scopes import available_scopes
 from oidcendpoint.session import setup_session
@@ -118,6 +119,21 @@ ALG_PARAMS = {
 
 def re_authenticate(request, authn):
     return False
+
+
+def check_unknown_scopes_policy(request_info, cinfo, endpoint_context):
+    op_capabilities = endpoint_context.conf['capabilities']
+    client_allowed_scopes = cinfo.get('allowed_scopes') or \
+                            op_capabilities['scopes_supported']
+
+    # this prevents that authz would be released for unavailable scopes
+    for scope in request_info['scope']:
+        if op_capabilities.get('deny_unknown_scopes') and \
+           scope not in client_allowed_scopes:
+            _msg = '{} requested an unauthorized scope ({})'
+            logger.warning(_msg.format(cinfo['client_id'],
+                                       scope))
+            raise UnAuthorizedClientScope()
 
 
 class Authorization(Endpoint):
@@ -590,6 +606,11 @@ class Authorization(Endpoint):
 
         _cid = request_info["client_id"]
         cinfo = self.endpoint_context.cdb[_cid]
+
+        logger.debug("client {}: {}".format(_cid, cinfo))
+
+        # this apply the default optionally deny_unknown_scopes policy
+        check_unknown_scopes_policy(request_info, cinfo, self.endpoint_context)
 
         cookie = kwargs.get("cookie", "")
         if cookie:

--- a/src/oidcendpoint/oidc/authorization.py
+++ b/src/oidcendpoint/oidc/authorization.py
@@ -37,6 +37,7 @@ from oidcendpoint.exception import ServiceError
 from oidcendpoint.exception import TamperAllert
 from oidcendpoint.exception import ToOld
 from oidcendpoint.exception import UnknownClient
+from oidcendpoint.oauth2.authorization import check_unknown_scopes_policy
 from oidcendpoint.session import setup_session
 from oidcendpoint.user_authn.authn_context import pick_auth
 
@@ -682,6 +683,9 @@ class Authorization(Endpoint):
         _cid = request_info["client_id"]
         cinfo = self.endpoint_context.cdb[_cid]
         logger.debug("client {}: {}".format(_cid, cinfo))
+
+        # this apply the default optionally deny_unknown_scopes policy
+        check_unknown_scopes_policy(request_info, cinfo, self.endpoint_context)
 
         cookie = kwargs.get("cookie", "")
         if cookie:

--- a/tests/test_24_oidc_authorization_endpoint.py
+++ b/tests/test_24_oidc_authorization_endpoint.py
@@ -115,11 +115,11 @@ client_yaml = """
 oidc_clients:
   client_1:
     "client_secret": 'hemligtkodord'
-    "redirect_uris": 
+    "redirect_uris":
         - ['https://example.com/cb', '']
     "client_salt": "salted"
     'token_endpoint_auth_method': 'client_secret_post'
-    'response_types': 
+    'response_types':
         - 'code'
         - 'token'
         - 'code id_token'


### PR DESCRIPTION
This PR would introduce something heavy but, in some case, useful.
Which those present some faulty RP/Client/RS where the token were not succesfully checked against the scopes for which the token was release for.

The option `deny_unknown_scopes` force the Authz endpoint (both OAuth2 and OIDC) to return a `invalid_scope` error message, with http status 400.

Configuration can be made as follow

````
op:
  server_info:
    issuer: *base_url
    httpc_params:
      verify: False
    session_key:
      filename: data/oidc_op/private/session_jwks.json
      type: OCT
      use: sig
    capabilities:
      # indicates that unknow/unavailable scopes requested by a RP
      # would get a 400 error message instead of be declined implicitly.
      # If False the op will only release the available scopes and ignoring the missings.
      # Default to False
      deny_unknown_scopes: true
````

This PR is a WiP that follows https://github.com/IdentityPython/oidcendpoint/issues/73 