### PR TITLE
Feature configurable grant types

### DIFF
--- a/src/oidcendpoint/oidc/token_coop.py
+++ b/src/oidcendpoint/oidc/token_coop.py
@@ -263,7 +263,10 @@ class TokenCoop(Endpoint):
         if _helper:
             return _helper.post_parse_request(request, client_id, **kwargs)
         else:
-            raise ProcessError("No support for grant_type: {}", request["grant_type"])
+            return self.error_cls(
+                error="invalid_request",
+                error_description=f"Unsupported grant_type: {request['grant_type']}"
+            )
 
     def process_request(self, request=None, **kwargs):
         """
@@ -281,9 +284,7 @@ class TokenCoop(Endpoint):
             else:
                 return self.error_cls(
                     error="invalid_request",
-                    error_description="Unsupported grant_type {}".format(
-                        request["grant_type"]
-                    ),
+                    error_description=f"Unsupported grant_type: {request['grant_type']}"
                 )
         except JWEException as err:
             return self.error_cls(error="invalid_request", error_description="%s" % err)

--- a/src/oidcendpoint/oidc/token_coop.py
+++ b/src/oidcendpoint/oidc/token_coop.py
@@ -248,7 +248,7 @@ class TokenCoop(Endpoint):
 
             try:
                 grant_class = grant_type_options["class"]
-            except KeyError:
+            except (KeyError, TypeError):
                 raise ProcessError(
                     "Token Endpoint's grant types must be True, None or a dict with a"
                     " 'class' key."
@@ -258,7 +258,7 @@ class TokenCoop(Endpoint):
             if isinstance(grant_class, str):
                 try:
                     grant_class = importer(grant_class)
-                except ValueError:
+                except (ValueError, AttributeError):
                     raise ProcessError(
                         f"Token Endpoint's grant type class {grant_class} can't"
                         " be imported."

--- a/tests/test_35_oidc_token_coop_endpoint.py
+++ b/tests/test_35_oidc_token_coop_endpoint.py
@@ -7,6 +7,7 @@ from cryptojwt.key_jar import build_keyjar
 from oidcmsg.oidc import AccessTokenRequest
 from oidcmsg.oidc import AuthorizationRequest
 from oidcmsg.oidc import RefreshAccessTokenRequest
+from oidcmsg.oidc import ResponseMessage
 
 from oidcendpoint import JWT_BEARER
 from oidcendpoint.client_authn import verify_client
@@ -205,8 +206,10 @@ class TestEndpoint(object):
     def test_errors_in_grant_types_supported(self, conf, grant_types_supported):
         token_conf = conf["endpoint"]["token"]
         token_conf["kwargs"]["grant_types_supported"] = grant_types_supported
-        with pytest.raises(Exception):
+        with pytest.raises(Exception) as exception_info:
             EndpointContext(conf)
+        assert exception_info.typename == "ProcessError"
+        assert "Token Endpoint" in str(exception_info.value)
 
     def test_parse(self):
         session_id = setup_session(self.endpoint.endpoint_context, AUTH_REQ, uid="user")
@@ -422,3 +425,49 @@ class TestEndpoint(object):
         assert "error_description" in _resp
         assert _resp["error"] == "invalid_request"
         assert _resp["error_description"] == "Unsupported grant_type: refresh_token"
+
+    def test_custom_grant_class(self, conf):
+        """
+        Register a custom grant type supported and see if it works as it should.
+        """
+        class CustomGrant:
+            def __init__(self, endpoint, config=None):
+                self.endpoint = endpoint
+
+            def post_parse_request(self, request, client_id="", **kwargs):
+                request.testvalue = "test"
+                return request
+
+            def process_request(self, request, **kwargs):
+                """
+                All grant types should return a ResponseMessage class or inherit it.
+                """
+                return ResponseMessage(test="successful")
+
+        token_conf = conf["endpoint"]["token"]
+        token_conf["kwargs"]["grant_types_supported"] = {
+            "authorization_code": True,
+            "test_grant": {
+                "class": CustomGrant
+            }
+        }
+        endpoint_context = EndpointContext(conf)
+        token_endpoint = endpoint_context.endpoint["token"]
+        token_endpoint.client_authn_method = [None]
+        endpoint_context.cdb["client_1"] = {
+            "client_secret": "hemligt",
+            "redirect_uris": [("https://example.com/cb", None)],
+            "client_salt": "salted",
+            "endpoint_auth_method": "client_secret_post",
+            "response_types": ["code", "token", "code id_token", "id_token"],
+        }
+        endpoint_context.keyjar.import_jwks(CLIENT_KEYJAR.export_jwks(), "client_1")
+
+        request = dict(grant_type="test_grant", client_id="client_1")
+
+        parsed_request = token_endpoint.parse_request(request)
+        assert parsed_request.testvalue == "test"
+
+        response = token_endpoint.process_request(parsed_request)
+        assert "test" in response
+        assert response["test"] == "successful"

--- a/tests/test_35_oidc_token_coop_endpoint.py
+++ b/tests/test_35_oidc_token_coop_endpoint.py
@@ -12,7 +12,6 @@ from oidcendpoint import JWT_BEARER
 from oidcendpoint.client_authn import verify_client
 from oidcendpoint.endpoint_context import EndpointContext
 from oidcendpoint.exception import MultipleCodeUsage
-from oidcendpoint.exception import ProcessError
 from oidcendpoint.exception import UnAuthorizedClient
 from oidcendpoint.oidc import userinfo
 from oidcendpoint.oidc.authorization import Authorization
@@ -368,5 +367,8 @@ class TestEndpoint(object):
 
         _request = REFRESH_TOKEN_REQ.copy()
         _request["refresh_token"] = _resp["response_args"]["refresh_token"]
-        with pytest.raises(ProcessError):
-            self.endpoint.parse_request(_request.to_json())
+        _resp = self.endpoint.parse_request(_request.to_json())
+        assert "error" in _resp
+        assert "error_description" in _resp
+        assert _resp["error"] == "invalid_request"
+        assert _resp["error_description"] == "Unsupported grant_type: refresh_token"

--- a/tests/test_35_oidc_token_coop_endpoint.py
+++ b/tests/test_35_oidc_token_coop_endpoint.py
@@ -18,6 +18,7 @@ from oidcendpoint.oidc import userinfo
 from oidcendpoint.oidc.authorization import Authorization
 from oidcendpoint.oidc.provider_config import ProviderConfiguration
 from oidcendpoint.oidc.registration import Registration
+from oidcendpoint.oidc.token_coop import AccessToken
 from oidcendpoint.oidc.token_coop import TokenCoop
 from oidcendpoint.session import setup_session
 from oidcendpoint.user_authn.authn_context import INTERNETPROTOCOLPASSWORD
@@ -363,7 +364,7 @@ class TestEndpoint(object):
         _req = self.endpoint.parse_request(_token_request)
         _resp = self.endpoint.process_request(request=_req)
 
-        self.endpoint.allow_refresh = False
+        self.endpoint.helper = {"authorization_code": AccessToken}
 
         _request = REFRESH_TOKEN_REQ.copy()
         _request["refresh_token"] = _resp["response_args"]["refresh_token"]

--- a/tests/test_35_oidc_token_coop_endpoint.py
+++ b/tests/test_35_oidc_token_coop_endpoint.py
@@ -174,7 +174,7 @@ class TestEndpoint(object):
             },
         },
         {
-            "authorization_code": "default",
+            "authorization_code": True,  # Both True and None end up using the defaults
             "refresh_token": None,  # This represents a key w/o value in the YAML conf
         },
     ])


### PR DESCRIPTION
As discussed in https://github.com/IdentityPython/oidcendpoint/pull/59#issuecomment-693260033, I split up the configurable grant types feature (originally by-grant-types) from the token exchange specific changes to make review easier.

This branch refactors token_coop module to allow configuring different handlers for each grant type configured.