### PR TITLE
Add add_scope option for JWT access token

### DIFF
--- a/src/oidcendpoint/scopes.py
+++ b/src/oidcendpoint/scopes.py
@@ -82,6 +82,10 @@ class Scopes:
                 return available_scopes(endpoint_context)
         return []
 
+    def filter_scopes(self, client_id, endpoint_context, scopes):
+        allowed_scopes = self.allowed_scopes(client_id, endpoint_context)
+        return [s for s in scopes if s in allowed_scopes]
+
 
 class Claims:
     def __init__(self):

--- a/src/oidcendpoint/userinfo.py
+++ b/src/oidcendpoint/userinfo.py
@@ -127,10 +127,9 @@ def collect_user_info(
     if scope_to_claims is None:
         scope_to_claims = endpoint_context.scope2claims
 
-    _allowed = endpoint_context.scopes_handler.allowed_scopes(
-        authn_req["client_id"], endpoint_context
+    supported_scopes = endpoint_context.scopes_handler.filter_scopes(
+        authn_req["client_id"], endpoint_context, authn_req["scope"]
     )
-    supported_scopes = [s for s in authn_req["scope"] if s in _allowed]
     if userinfo_claims is None:
         _allowed_claims = endpoint_context.claims_handler.allowed_claims(
             authn_req["client_id"], endpoint_context

--- a/tests/test_27_jwt_token.py
+++ b/tests/test_27_jwt_token.py
@@ -205,6 +205,21 @@ class TestEndpoint(object):
         res = _jwt.unpack(token)
         assert enable_claims_per_client is ("address" in res)
 
+    @pytest.mark.parametrize("add_scope", [True, False])
+    def test_add_scopes(self, add_scope):
+        ec = self.endpoint.endpoint_context
+        handler = ec.sdb.handler.handler["access_token"]
+        auth_req = dict(AUTH_REQ)
+        auth_req["scope"] = ["openid", "profile", "aba"]
+        session_id = setup_session(ec, auth_req, uid="diana")
+        handler.add_scope = add_scope
+        _dic = ec.sdb.upgrade_to_token(key=session_id)
+
+        token = _dic["access_token"]
+        _jwt = JWT(key_jar=KEYJAR, iss="client_1")
+        res = _jwt.unpack(token)
+        assert add_scope is (res.get("scope") == ["openid", "profile"])
+
     def test_is_expired(self):
         session_id = setup_session(
             self.endpoint.endpoint_context, AUTH_REQ, uid="diana"


### PR DESCRIPTION
Add add_scope option JWT access tokens, enabling this will add a list
with the allowed scopes that were requested in the returned JWT.