### PR TITLE
Add the option to include hashes in the idtoken

### DIFF
--- a/src/oidcendpoint/id_token.py
+++ b/src/oidcendpoint/id_token.py
@@ -113,6 +113,8 @@ class IDToken(object):
         self.endpoint_context = endpoint_context
         self.kwargs = kwargs
         self.enable_claims_per_client = kwargs.get("enable_claims_per_client", False)
+        self.add_c_hash = kwargs.get("add_c_hash", True)
+        self.add_at_hash = kwargs.get("add_at_hash", True)
         self.scope_to_claims = None
         self.provider_info = construct_endpoint_info(
             self.default_capabilities, **kwargs
@@ -176,8 +178,16 @@ class IDToken(object):
         halg = "HS%s" % alg[-3:]
         if code:
             _args["c_hash"] = left_hash(code.encode("utf-8"), halg)
+        elif self.add_c_hash and session.get("code"):
+            _args["c_hash"] = left_hash(
+                session.get("code").encode("utf-8"), halg
+            )
         if access_token:
             _args["at_hash"] = left_hash(access_token.encode("utf-8"), halg)
+        elif self.add_at_hash and session.get("access_token"):
+            _args["at_hash"] = left_hash(
+                session.get("access_token").encode("utf-8"), halg
+            )
 
         authn_req = session["authn_req"]
         if authn_req:

--- a/tests/test_03_id_token.py
+++ b/tests/test_03_id_token.py
@@ -120,6 +120,26 @@ class TestEndpoint(object):
         }
         assert info["lifetime"] == 300
 
+    @pytest.mark.parametrize("add_c_hash", [True, False])
+    def test_id_token_payload_with_code_in_session(self, add_c_hash):
+        self.endpoint_context.idtoken.add_c_hash = add_c_hash
+        code = "ABCDEFGHIJKLMNOP"
+        session_info = {"authn_req": AREQN, "sub": "1234567890", "code": code}
+
+        info = self.endpoint_context.idtoken.payload(session_info)
+        if add_c_hash:
+            assert info["payload"] == {
+                "nonce": "nonce",
+                "sub": "1234567890",
+                "c_hash": "5-i4nCch0pDMX1VCVJHs1g",
+            }
+        else:
+            assert info["payload"] == {
+                "nonce": "nonce",
+                "sub": "1234567890",
+            }
+        assert info["lifetime"] == 300
+
     def test_id_token_payload_with_access_token(self):
         session_info = {"authn_req": AREQN, "sub": "1234567890"}
 
@@ -131,6 +151,30 @@ class TestEndpoint(object):
             "at_hash": "bKkyhbn1CC8IMdavzOV-Qg",
             "sub": "1234567890",
         }
+        assert info["lifetime"] == 300
+
+    @pytest.mark.parametrize("add_at_hash", [True, False])
+    def test_id_token_payload_with_access_token_in_session(self, add_at_hash):
+        self.endpoint_context.idtoken.add_at_hash = add_at_hash
+        access_token = "012ABCDEFGHIJKLMNOP"
+        session_info = {
+            "authn_req": AREQN,
+            "sub": "1234567890",
+            "access_token": access_token
+        }
+
+        info = self.endpoint_context.idtoken.payload(session_info)
+        if add_at_hash:
+            assert info["payload"] == {
+                "nonce": "nonce",
+                "sub": "1234567890",
+                "at_hash": "bKkyhbn1CC8IMdavzOV-Qg",
+            }
+        else:
+            assert info["payload"] == {
+                "nonce": "nonce",
+                "sub": "1234567890",
+            }
         assert info["lifetime"] == 300
 
     def test_id_token_payload_with_code_and_access_token(self):
@@ -145,6 +189,36 @@ class TestEndpoint(object):
             "c_hash": "5-i4nCch0pDMX1VCVJHs1g",
             "sub": "1234567890",
         }
+        assert info["lifetime"] == 300
+
+    @pytest.mark.parametrize("add_hashes", [True, False])
+    def test_id_token_payload_with_code_and_access_token_in_session(
+        self, add_hashes
+    ):
+        self.endpoint_context.idtoken.add_c_hash = add_hashes
+        self.endpoint_context.idtoken.add_at_hash = add_hashes
+        code = "ABCDEFGHIJKLMNOP"
+        access_token = "012ABCDEFGHIJKLMNOP"
+        session_info = {
+            "authn_req": AREQN,
+            "sub": "1234567890",
+            "access_token": access_token,
+            "code": code,
+        }
+
+        info = self.endpoint_context.idtoken.payload(session_info)
+        if add_hashes:
+            assert info["payload"] == {
+                "nonce": "nonce",
+                "sub": "1234567890",
+                "at_hash": "bKkyhbn1CC8IMdavzOV-Qg",
+                "c_hash": "5-i4nCch0pDMX1VCVJHs1g",
+            }
+        else:
+            assert info["payload"] == {
+                "nonce": "nonce",
+                "sub": "1234567890",
+            }
         assert info["lifetime"] == 300
 
     def test_id_token_payload_with_userinfo(self):


### PR DESCRIPTION
Add the options `add_c_hash` and `add_at_hash` to retrieve the tokens from
the session_info and add their hashes to the id token