### PR TITLE
fail gracefully when clean_sessions() fails

### DIFF
--- a/src/oidcendpoint/oidc/session.py
+++ b/src/oidcendpoint/oidc/session.py
@@ -166,7 +166,10 @@ class Session(Endpoint):
                 if _spec:
                     fc_iframes[_cid] = _spec
 
-        self.clean_sessions(usids)
+        try:
+            self.clean_sessions(usids)
+        except KeyError:
+            pass
 
         res = {}
         if bc_logouts:
@@ -211,7 +214,11 @@ class Session(Endpoint):
             if _spec:
                 res["flu"] = {client_id: _spec}
 
-        self.clean_sessions([sid])
+        try:
+            self.clean_sessions([sid])
+        except KeyError:
+            pass
+
         return res
 
     def process_request(self, request=None, cookie=None, **kwargs):


### PR DESCRIPTION
I'm experiencing failures when cleaning session, this fix will ignore failures when cleaning sessions.