### PR TITLE
Fix token endpoint info

### DIFF
--- a/src/oidcendpoint/endpoint.py
+++ b/src/oidcendpoint/endpoint.py
@@ -117,6 +117,14 @@ def construct_endpoint_info(default_capabilities, **kwargs):
                     _info[attr] = default_val
                 elif "signing_alg_values_supported" in attr:
                     _info[attr] = assign_algorithms("signing_alg")
+                    if (
+                        attr
+                        == "token_endpoint_auth_signing_alg_values_supported"
+                    ):
+                        # none must not be in
+                        # token_endpoint_auth_signing_alg_values_supported
+                        if "none" in _info[attr]:
+                            _info[attr].remove("none")
                 elif "encryption_alg_values_supported" in attr:
                     _info[attr] = assign_algorithms("encryption_alg")
                 elif "encryption_enc_values_supported" in attr:

--- a/src/oidcendpoint/oidc/add_on/pkce.py
+++ b/src/oidcendpoint/oidc/add_on/pkce.py
@@ -5,6 +5,9 @@ from cryptojwt.utils import b64e
 from oidcmsg.oauth2 import AuthorizationErrorResponse
 from oidcmsg.oidc import TokenErrorResponse
 
+from oidcendpoint.exception import MultipleCodeUsage
+from oidcendpoint.token_handler import UnknownToken
+
 LOGGER = logging.getLogger(__name__)
 
 
@@ -92,12 +95,9 @@ def post_token_parse(request, client_id, endpoint_context, **kwargs):
     if isinstance(request, AuthorizationErrorResponse):
         return request
 
-    try:
-        _info = endpoint_context.sdb[request["code"]]
-    except KeyError:
-        return TokenErrorResponse(
-            error="invalid_grant", error_description="Unknown access grant"
-        )
+    # We can be sure that the code is there. The flow would have failed
+    # earlier if it wasn't
+    _info = endpoint_context.sdb[request["code"]]
     _authn_req = _info["authn_req"]
 
     if "code_challenge" in _authn_req:

--- a/src/oidcendpoint/oidc/token_coop.py
+++ b/src/oidcendpoint/oidc/token_coop.py
@@ -15,9 +15,11 @@ from oidcmsg.storage import importer
 from oidcendpoint import sanitize
 from oidcendpoint.cookie import new_cookie
 from oidcendpoint.endpoint import Endpoint
+from oidcendpoint.exception import MultipleCodeUsage
 from oidcendpoint.exception import ProcessError
 from oidcendpoint.token_handler import AccessCodeUsed
 from oidcendpoint.token_handler import ExpiredToken
+from oidcendpoint.token_handler import UnknownToken
 from oidcendpoint.userinfo import by_schema
 
 logger = logging.getLogger(__name__)
@@ -67,17 +69,28 @@ class AccessToken(TokenEndpointHelper):
         if "state" not in request:
             return
 
+        if "code" not in request:
+            return self.endpoint.error_cls(
+                error="invalid_request", error_description="Missing code"
+            )
+
         try:
             sinfo = self.endpoint.endpoint_context.sdb[request["code"]]
-        except KeyError:
+        except (KeyError, UnknownToken):
             logger.error("Code not present in SessionDB")
-            return self.endpoint.error_cls(error="unauthorized_client")
+            return self.endpoint.error_cls(
+                error="invalid_grant", error_description="Invalid code"
+            )
+        except MultipleCodeUsage:
+            return self.endpoint.error_cls(
+                error="invalid_grant", error_description="Code is already used"
+            )
         else:
             state = sinfo["authn_req"]["state"]
 
         if state != request["state"]:
             logger.error("State value mismatch")
-            return self.endpoint.error_cls(error="unauthorized_client")
+            return self.endpoint.error_cls(error="invalid_request")
 
     def process_request(self, req, **kwargs):
         _context = self.endpoint.endpoint_context
@@ -91,13 +104,9 @@ class AccessToken(TokenEndpointHelper):
                 error="invalid_request", error_description="Missing code"
             )
 
-        # Session might not exist or _access_code malformed
-        try:
-            _info = _sdb[_access_code]
-        except KeyError:
-            return self.endpoint.error_cls(
-                error="invalid_grant", error_description="Code is invalid"
-            )
+        # We can be sure that the code is there. The flow would have failed
+        # earlier if it wasn't
+        _info = _sdb[_access_code]
 
         _authn_req = _info["authn_req"]
 

--- a/tests/test_25_oidc_token_endpoint.py
+++ b/tests/test_25_oidc_token_endpoint.py
@@ -160,6 +160,17 @@ class TestEndpoint(object):
     def test_init(self):
         assert self.endpoint
 
+    def test_signing_alg_values(self):
+        """
+        According to
+        https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderMetadata
+        The value "none" MUST NOT be used for the
+        token_endpoint_auth_signing_alg_values_supported field.
+        """
+        assert "none" not in self.endpoint.endpoint_info[
+            "token_endpoint_auth_signing_alg_values_supported"
+        ]
+
     def test_parse(self):
         session_id = setup_session(self.endpoint.endpoint_context, AUTH_REQ, uid="user")
         _token_request = TOKEN_REQ_DICT.copy()

--- a/tests/test_33_pkce.py
+++ b/tests/test_33_pkce.py
@@ -14,6 +14,7 @@ from oidcmsg.oidc import TokenErrorResponse
 
 from oidcendpoint.cookie import CookieDealer
 from oidcendpoint.endpoint_context import EndpointContext
+from oidcendpoint.exception import MultipleCodeUsage
 from oidcendpoint.id_token import IDToken
 from oidcendpoint.oidc.add_on.pkce import CC_METHOD
 from oidcendpoint.oidc.authorization import Authorization
@@ -119,6 +120,9 @@ def conf():
         "verify_ssl": False,
         "capabilities": CAPABILITIES,
         "keys": {"uri_path": "static/jwks.json", "key_defs": KEYDEFS},
+        "userinfo": {
+            "class": "oidcendpoint.user_info.UserInfo",
+        },
         "id_token": {
             "class": IDToken,
             "kwargs": {
@@ -243,6 +247,54 @@ class TestEndpoint(object):
         _req = self.token_endpoint.parse_request(_token_request)
 
         assert isinstance(_req, AccessTokenRequest)
+
+    def test_reuse_code(self):
+        """
+        Parsing should no fail because of pkce if the code is reused
+        """
+        _cc_info = _code_challenge()
+        _authn_req = AUTH_REQ.copy()
+        _authn_req["code_challenge"] = _cc_info["code_challenge"]
+        _authn_req["code_challenge_method"] = _cc_info["code_challenge_method"]
+
+        _pr_resp = self.authn_endpoint.parse_request(_authn_req.to_dict())
+        resp = self.authn_endpoint.process_request(_pr_resp)
+
+        assert isinstance(resp["response_args"], AuthorizationResponse)
+
+        _token_request = TOKEN_REQ.copy()
+        _token_request["code"] = resp["response_args"]["code"]
+        _token_request["code_verifier"] = _cc_info["code_verifier"]
+        _req = self.token_endpoint.parse_request(_token_request)
+        self.token_endpoint.process_request(_req)
+
+        _req = self.token_endpoint.parse_request(_token_request)
+        resp = self.token_endpoint.process_request(_req)
+        assert isinstance(resp, TokenErrorResponse)
+
+    def test_invalid_code(self):
+        """
+        Parsing should no fail because of pkce if the code is invalid
+        """
+        _cc_info = _code_challenge()
+        _authn_req = AUTH_REQ.copy()
+        _authn_req["code_challenge"] = _cc_info["code_challenge"]
+        _authn_req["code_challenge_method"] = _cc_info["code_challenge_method"]
+
+        _pr_resp = self.authn_endpoint.parse_request(_authn_req.to_dict())
+        resp = self.authn_endpoint.process_request(_pr_resp)
+
+        assert isinstance(resp["response_args"], AuthorizationResponse)
+
+        _token_request = TOKEN_REQ.copy()
+        _token_request["code"] = resp["response_args"]["code"]
+        _token_request["code_verifier"] = _cc_info["code_verifier"]
+        _req = self.token_endpoint.parse_request(_token_request)
+        self.token_endpoint.process_request(_req)
+
+        _req = self.token_endpoint.parse_request(_token_request)
+        resp = self.token_endpoint.process_request(_req)
+        assert isinstance(resp, TokenErrorResponse)
 
     def test_no_code_challenge_method(self):
         _cc_info = _code_challenge()

--- a/tests/test_35_oidc_token_coop_endpoint.py
+++ b/tests/test_35_oidc_token_coop_endpoint.py
@@ -211,6 +211,17 @@ class TestEndpoint(object):
         assert exception_info.typename == "ProcessError"
         assert "Token Endpoint" in str(exception_info.value)
 
+    def test_signing_alg_values(self):
+        """
+        According to
+        https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderMetadata
+        The value "none" MUST NOT be used for the
+        token_endpoint_auth_signing_alg_values_supported field.
+        """
+        assert "none" not in self.endpoint.endpoint_info[
+            "token_endpoint_auth_signing_alg_values_supported"
+        ]
+
     def test_parse(self):
         session_id = setup_session(self.endpoint.endpoint_context, AUTH_REQ, uid="user")
         _token_request = TOKEN_REQ_DICT.copy()

--- a/tests/test_35_oidc_token_coop_endpoint.py
+++ b/tests/test_35_oidc_token_coop_endpoint.py
@@ -8,6 +8,7 @@ from oidcmsg.oidc import AccessTokenRequest
 from oidcmsg.oidc import AuthorizationRequest
 from oidcmsg.oidc import RefreshAccessTokenRequest
 from oidcmsg.oidc import ResponseMessage
+from oidcmsg.oidc import TokenErrorResponse
 
 from oidcendpoint import JWT_BEARER
 from oidcendpoint.client_authn import verify_client
@@ -261,11 +262,31 @@ class TestEndpoint(object):
         _token_request["code"] = _context.sdb[session_id]["code"]
         _context.sdb.update(session_id, user="diana")
         _req = self.endpoint.parse_request(_token_request)
+        self.endpoint.process_request(request=_req)
+
+        _resp = self.endpoint.parse_request(_token_request)
+        assert isinstance(_resp, TokenErrorResponse)
+        assert _resp["error"] == "invalid_grant"
+        assert _resp["error_description"] == "Code is already used"
+
+    def test_process_request_using_invalid_code(self):
+        _token_request = TOKEN_REQ_DICT.copy()
+        _token_request["code"] = "code"
+        _req = self.endpoint.parse_request(_token_request)
         _resp = self.endpoint.process_request(request=_req)
 
-        # 2nd time used
-        with pytest.raises(MultipleCodeUsage):
-            self.endpoint.parse_request(_token_request)
+        assert isinstance(_resp, TokenErrorResponse)
+        assert _resp["error"] == "invalid_grant"
+        assert _resp["error_description"] == "Invalid code"
+
+    def test_process_request_using_no_code(self):
+        _token_request = TOKEN_REQ_DICT.copy()
+        _req = self.endpoint.parse_request(_token_request)
+        _resp = self.endpoint.process_request(request=_req)
+
+        assert isinstance(_resp, TokenErrorResponse)
+        assert _resp["error"] == "invalid_request"
+        assert _resp["error_description"] == "Missing code"
 
     def test_do_response(self):
         session_id = setup_session(


### PR DESCRIPTION
According to https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderMetadata
the value "none" must not be used for `token_endpoint_auth_signing_alg_values_supported`