### PR TITLE
Fix invalid/missing codes in token endpoint

### DIFF
--- a/src/oidcendpoint/oidc/add_on/pkce.py
+++ b/src/oidcendpoint/oidc/add_on/pkce.py
@@ -5,6 +5,9 @@ from cryptojwt.utils import b64e
 from oidcmsg.oauth2 import AuthorizationErrorResponse
 from oidcmsg.oidc import TokenErrorResponse
 
+from oidcendpoint.exception import MultipleCodeUsage
+from oidcendpoint.token_handler import UnknownToken
+
 LOGGER = logging.getLogger(__name__)
 
 
@@ -94,10 +97,9 @@ def post_token_parse(request, client_id, endpoint_context, **kwargs):
 
     try:
         _info = endpoint_context.sdb[request["code"]]
-    except KeyError:
-        return TokenErrorResponse(
-            error="invalid_grant", error_description="Unknown access grant"
-        )
+    except (KeyError, UnknownToken, MultipleCodeUsage):
+        # This will be handled by process_request
+        return request
     _authn_req = _info["authn_req"]
 
     if "code_challenge" in _authn_req:

--- a/tests/test_33_pkce.py
+++ b/tests/test_33_pkce.py
@@ -17,7 +17,7 @@ from oidcendpoint.endpoint_context import EndpointContext
 from oidcendpoint.id_token import IDToken
 from oidcendpoint.oidc.add_on.pkce import CC_METHOD
 from oidcendpoint.oidc.authorization import Authorization
-from oidcendpoint.oidc.token import AccessToken
+from oidcendpoint.oidc.token_coop import TokenCoop
 
 BASECH = string.ascii_letters + string.digits + "-._~"
 
@@ -119,6 +119,9 @@ def conf():
         "verify_ssl": False,
         "capabilities": CAPABILITIES,
         "keys": {"uri_path": "static/jwks.json", "key_defs": KEYDEFS},
+        "userinfo": {
+            "class": "oidcendpoint.user_info.UserInfo",
+        },
         "id_token": {
             "class": IDToken,
             "kwargs": {
@@ -136,7 +139,7 @@ def conf():
             },
             "token": {
                 "path": "{}/token",
-                "class": AccessToken,
+                "class": TokenCoop,
                 "kwargs": {
                     "client_authn_method": [
                         "client_secret_post",
@@ -243,6 +246,54 @@ class TestEndpoint(object):
         _req = self.token_endpoint.parse_request(_token_request)
 
         assert isinstance(_req, AccessTokenRequest)
+
+    def test_reuse_code(self):
+        """
+        Parsing should no fail because of pkce if the code is reused
+        """
+        _cc_info = _code_challenge()
+        _authn_req = AUTH_REQ.copy()
+        _authn_req["code_challenge"] = _cc_info["code_challenge"]
+        _authn_req["code_challenge_method"] = _cc_info["code_challenge_method"]
+
+        _pr_resp = self.authn_endpoint.parse_request(_authn_req.to_dict())
+        resp = self.authn_endpoint.process_request(_pr_resp)
+
+        assert isinstance(resp["response_args"], AuthorizationResponse)
+
+        _token_request = TOKEN_REQ.copy()
+        _token_request["code"] = resp["response_args"]["code"]
+        _token_request["code_verifier"] = _cc_info["code_verifier"]
+        _req = self.token_endpoint.parse_request(_token_request)
+        self.token_endpoint.process_request(_req)
+
+        _req = self.token_endpoint.parse_request(_token_request)
+        resp = self.token_endpoint.process_request(_req)
+        assert isinstance(resp, TokenErrorResponse)
+
+    def test_invalid_code(self):
+        """
+        Parsing should no fail because of pkce if the code is invalid
+        """
+        _cc_info = _code_challenge()
+        _authn_req = AUTH_REQ.copy()
+        _authn_req["code_challenge"] = _cc_info["code_challenge"]
+        _authn_req["code_challenge_method"] = _cc_info["code_challenge_method"]
+
+        _pr_resp = self.authn_endpoint.parse_request(_authn_req.to_dict())
+        resp = self.authn_endpoint.process_request(_pr_resp)
+
+        assert isinstance(resp["response_args"], AuthorizationResponse)
+
+        _token_request = TOKEN_REQ.copy()
+        _token_request["code"] = resp["response_args"]["code"]
+        _token_request["code_verifier"] = _cc_info["code_verifier"]
+        _req = self.token_endpoint.parse_request(_token_request)
+        self.token_endpoint.process_request(_req)
+
+        _req = self.token_endpoint.parse_request(_token_request)
+        resp = self.token_endpoint.process_request(_req)
+        assert isinstance(resp, TokenErrorResponse)
 
     def test_no_code_challenge_method(self):
         _cc_info = _code_challenge()

--- a/tests/test_35_oidc_token_coop_endpoint.py
+++ b/tests/test_35_oidc_token_coop_endpoint.py
@@ -8,6 +8,7 @@ from oidcmsg.oidc import AccessTokenRequest
 from oidcmsg.oidc import AuthorizationRequest
 from oidcmsg.oidc import RefreshAccessTokenRequest
 from oidcmsg.oidc import ResponseMessage
+from oidcmsg.oidc import TokenErrorResponse
 
 from oidcendpoint import JWT_BEARER
 from oidcendpoint.client_authn import verify_client
@@ -250,11 +251,32 @@ class TestEndpoint(object):
         _token_request["code"] = _context.sdb[session_id]["code"]
         _context.sdb.update(session_id, user="diana")
         _req = self.endpoint.parse_request(_token_request)
+        self.endpoint.process_request(request=_req)
+
+        req = self.endpoint.parse_request(_token_request)
+        _resp = self.endpoint.process_request(request=_req)
+        assert isinstance(_resp, TokenErrorResponse)
+        assert _resp["error"] == "invalid_grant"
+        assert _resp["error_description"] == "Code is already used"
+
+    def test_process_request_using_invalid_code(self):
+        _token_request = TOKEN_REQ_DICT.copy()
+        _token_request["code"] = "code"
+        _req = self.endpoint.parse_request(_token_request)
         _resp = self.endpoint.process_request(request=_req)
 
-        # 2nd time used
-        with pytest.raises(MultipleCodeUsage):
-            self.endpoint.parse_request(_token_request)
+        assert isinstance(_resp, TokenErrorResponse)
+        assert _resp["error"] == "invalid_grant"
+        assert _resp["error_description"] == "Invalid code"
+
+    def test_process_request_using_no_code(self):
+        _token_request = TOKEN_REQ_DICT.copy()
+        _req = self.endpoint.parse_request(_token_request)
+        _resp = self.endpoint.process_request(request=_req)
+
+        assert isinstance(_resp, TokenErrorResponse)
+        assert _resp["error"] == "invalid_request"
+        assert _resp["error_description"] == "Missing code"
 
     def test_do_response(self):
         session_id = setup_session(


### PR DESCRIPTION
PKCE would fail if the code was invalid or already used, also the token `process_request` would raise if code was reused.

These will probably be fixed with the new session management, but since we don't know when it will be merged these fixes are nice to have until then