### PR TITLE
Fix token endpoint info

### DIFF
--- a/src/oidcendpoint/endpoint.py
+++ b/src/oidcendpoint/endpoint.py
@@ -117,6 +117,14 @@ def construct_endpoint_info(default_capabilities, **kwargs):
                     _info[attr] = default_val
                 elif "signing_alg_values_supported" in attr:
                     _info[attr] = assign_algorithms("signing_alg")
+                    if (
+                        attr
+                        == "token_endpoint_auth_signing_alg_values_supported"
+                    ):
+                        # none must not be in
+                        # token_endpoint_auth_signing_alg_values_supported
+                        if "none" in _info[attr]:
+                            _info[attr].remove("none")
                 elif "encryption_alg_values_supported" in attr:
                     _info[attr] = assign_algorithms("encryption_alg")
                 elif "encryption_enc_values_supported" in attr:

--- a/tests/test_25_oidc_token_endpoint.py
+++ b/tests/test_25_oidc_token_endpoint.py
@@ -160,6 +160,17 @@ class TestEndpoint(object):
     def test_init(self):
         assert self.endpoint
 
+    def test_signing_alg_values(self):
+        """
+        According to
+        https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderMetadata
+        The value "none" MUST NOT be used for the
+        token_endpoint_auth_signing_alg_values_supported field.
+        """
+        assert "none" not in self.endpoint.endpoint_info[
+            "token_endpoint_auth_signing_alg_values_supported"
+        ]
+
     def test_parse(self):
         session_id = setup_session(self.endpoint.endpoint_context, AUTH_REQ, uid="user")
         _token_request = TOKEN_REQ_DICT.copy()

--- a/tests/test_35_oidc_token_coop_endpoint.py
+++ b/tests/test_35_oidc_token_coop_endpoint.py
@@ -211,6 +211,17 @@ class TestEndpoint(object):
         assert exception_info.typename == "ProcessError"
         assert "Token Endpoint" in str(exception_info.value)
 
+    def test_signing_alg_values(self):
+        """
+        According to
+        https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderMetadata
+        The value "none" MUST NOT be used for the
+        token_endpoint_auth_signing_alg_values_supported field.
+        """
+        assert "none" not in self.endpoint.endpoint_info[
+            "token_endpoint_auth_signing_alg_values_supported"
+        ]
+
     def test_parse(self):
         session_id = setup_session(self.endpoint.endpoint_context, AUTH_REQ, uid="user")
         _token_request = TOKEN_REQ_DICT.copy()


### PR DESCRIPTION
According to
https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderMetadata
the value "none" must not be used for
`token_endpoint_auth_signing_alg_values_supported`

Duplicate of https://github.com/IdentityPython/oidcendpoint/pull/99. The previous PR was merged with one extra commit.