### PR TITLE
Refactor do_sub

### DIFF
--- a/src/oidcendpoint/oauth2/authorization.py
+++ b/src/oidcendpoint/oauth2/authorization.py
@@ -530,18 +530,39 @@ class Authorization(Endpoint):
 
         return response_info
 
-    def authz_part2(self, user, authn_event, request, **kwargs):
+    def authz_part2(
+        self,
+        user,
+        authn_event,
+        request,
+        subject_type=None,
+        acr=None,
+        salt=None,
+        sector_id=None,
+        **kwargs,
+    ):
         """
         After the authentication this is where you should end up
 
         :param user:
+        :param authn_event: The Authorization Event
         :param request: The Authorization Request
-        :param sid: Session key
+        :param subject_type: The subject_type
+        :param acr: The acr
+        :param salt: The salt used to produce the sub
+        :param sector_id: The sector_id used to produce the sub
         :param kwargs: possible other parameters
         :return: A redirect to the redirect_uri of the client
         """
         sid = setup_session(
-            self.endpoint_context, request, user, authn_event=authn_event
+            self.endpoint_context,
+            request,
+            user,
+            acr=acr,
+            salt=salt,
+            authn_event=authn_event,
+            subject_type=subject_type,
+            sector_id=sector_id,
         )
 
         try:

--- a/src/oidcendpoint/oidc/authorization.py
+++ b/src/oidcendpoint/oidc/authorization.py
@@ -602,18 +602,39 @@ class Authorization(Endpoint):
 
         return response_info
 
-    def authz_part2(self, user, authn_event, request, **kwargs):
+    def authz_part2(
+        self,
+        user,
+        authn_event,
+        request,
+        subject_type=None,
+        acr=None,
+        salt=None,
+        sector_id=None,
+        **kwargs,
+    ):
         """
         After the authentication this is where you should end up
 
         :param user:
+        :param authn_event: The Authorization Event
         :param request: The Authorization Request
-        :param sid: Session key
+        :param subject_type: The subject_type
+        :param acr: The acr
+        :param salt: The salt used to produce the sub
+        :param sector_id: The sector_id used to produce the sub
         :param kwargs: possible other parameters
         :return: A redirect to the redirect_uri of the client
         """
         sid = setup_session(
-            self.endpoint_context, request, user, authn_event=authn_event
+            self.endpoint_context,
+            request,
+            user,
+            acr=acr,
+            salt=salt,
+            authn_event=authn_event,
+            subject_type=subject_type,
+            sector_id=sector_id,
         )
 
         try:

--- a/src/oidcendpoint/util.py
+++ b/src/oidcendpoint/util.py
@@ -4,6 +4,7 @@ import logging
 from urllib.parse import parse_qs
 from urllib.parse import urlsplit
 from urllib.parse import urlunsplit
+from urllib.parse import urlparse
 
 from oidcendpoint.exception import OidcEndpointError
 
@@ -195,3 +196,20 @@ def allow_refresh_token(endpoint_context):
         raise OidcEndpointError('Grant type "refresh_token" lacks support')
 
     return False
+
+
+def sector_id_from_redirect_uris(uris):
+    if not uris:
+        return ""
+
+    hostname = urlparse(uris[0]).netloc
+    for uri in uris:
+        parsed = urlparse(uri)
+
+        if hostname != parsed.netloc:
+            raise OidcEndpointError(
+                "All redirect_uris must have the same hostname in order to "
+                "generate "
+            )
+
+    return hostname

--- a/tests/test_08_session.py
+++ b/tests/test_08_session.py
@@ -111,7 +111,7 @@ class TestSessionDB(object):
     def test_create_authz_session(self):
         ae = create_authn_event("uid", "salt")
         sid = self.sdb.create_authz_session(ae, AREQ, client_id="client_id")
-        self.sdb.do_sub(sid, uid="user", client_salt="client_salt")
+        self.sdb.do_sub(sid, uid="user", salt="client_salt")
 
         info = self.sdb[sid]
         assert info["client_id"] == "client_id"


### PR DESCRIPTION
Some arguments (like `subject_type`) were never passed to `do_sub`.
properly initialize `sector_id` according to https://openid.net/specs/openid-connect-core-1_0.html#PairwiseAlg.
The caller can pass arguments to do_sub.